### PR TITLE
Core improvements: IMediatorBuilder, Result.Accepted with location, safe Result conversion

### DIFF
--- a/src/Foundatio.Mediator.Abstractions/IMediatorBuilder.cs
+++ b/src/Foundatio.Mediator.Abstractions/IMediatorBuilder.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Foundatio.Mediator;
+
+/// <summary>
+/// A builder for configuring Foundatio.Mediator services.
+/// Extension methods on this interface allow distributed, transport, and other
+/// packages to add fluent configuration to the <c>AddMediator()</c> call chain.
+/// </summary>
+public interface IMediatorBuilder
+{
+    /// <summary>
+    /// Gets the underlying service collection.
+    /// </summary>
+    IServiceCollection Services { get; }
+}
+
+/// <inheritdoc />
+public sealed class MediatorBuilder : IMediatorBuilder
+{
+    /// <summary>
+    /// Creates a new <see cref="MediatorBuilder"/> wrapping the specified service collection.
+    /// </summary>
+    public MediatorBuilder(IServiceCollection services)
+    {
+        Services = services;
+    }
+
+    /// <inheritdoc />
+    public IServiceCollection Services { get; }
+}

--- a/src/Foundatio.Mediator.Abstractions/MediatorExtensions.cs
+++ b/src/Foundatio.Mediator.Abstractions/MediatorExtensions.cs
@@ -25,11 +25,11 @@ public static class MediatorExtensions
     /// </remarks>
     /// <param name="services">The service collection to add the mediator to.</param>
     /// <param name="options">Optional configuration options for the mediator.</param>
-    /// <returns>The updated service collection with Foundatio.Mediator registered.</returns>
-    public static IServiceCollection AddMediator(this IServiceCollection services, MediatorOptions? options = null)
+    /// <returns>A <see cref="IMediatorBuilder"/> for further configuration.</returns>
+    public static IMediatorBuilder AddMediator(this IServiceCollection services, MediatorOptions? options = null)
     {
         if (services.Any(sd => sd.ServiceType == typeof(IMediator)))
-            return services;
+            return new MediatorBuilder(services);
 
         options ??= new MediatorOptions();
 
@@ -83,13 +83,13 @@ public static class MediatorExtensions
         services.TryAddSingleton<IHandlerAuthorizationService, DefaultHandlerAuthorizationService>();
         services.TryAddSingleton<IAuthorizationContextProvider, DefaultAuthorizationContextProvider>();
 
-        return services;
+        return new MediatorBuilder(services);
     }
 
     /// <summary>
     /// Adds Foundatio.Mediator to the service collection with a configuration builder.
     /// </summary>
-    public static IServiceCollection AddMediator(this IServiceCollection services, Action<MediatorOptionsBuilder> builder)
+    public static IMediatorBuilder AddMediator(this IServiceCollection services, Action<MediatorOptionsBuilder> builder)
     {
         var optionsBuilder = new MediatorOptionsBuilder();
         builder(optionsBuilder);

--- a/src/Foundatio.Mediator.Abstractions/Result.Generic.cs
+++ b/src/Foundatio.Mediator.Abstractions/Result.Generic.cs
@@ -217,6 +217,19 @@ public sealed class Result<T> : IResult
     };
 
     /// <summary>
+    /// Creates a result indicating the request has been accepted for processing with a message and location.
+    /// </summary>
+    /// <param name="message">A message describing the accepted request.</param>
+    /// <param name="location">The location for tracking the accepted request (e.g. a job ID or status URL).</param>
+    /// <returns>A result with Accepted status, message, and location.</returns>
+    public static Result<T> Accepted(string message, string location) => new()
+    {
+        Status = ResultStatus.Accepted,
+        Message = message,
+        Location = location
+    };
+
+    /// <summary>
     /// Creates a result indicating successful creation of a resource with a location.
     /// </summary>
     /// <param name="value">The created resource.</param>

--- a/src/Foundatio.Mediator.Abstractions/Result.cs
+++ b/src/Foundatio.Mediator.Abstractions/Result.cs
@@ -62,6 +62,19 @@ public sealed class Result : IResult
     };
 
     /// <summary>
+    /// Creates a Result from an <see cref="IResult"/>.
+    /// </summary>
+    /// <param name="result">The result to convert.</param>
+    /// <returns>A Result instance.</returns>
+    public static Result FromResult(IResult result) => new()
+    {
+        Status = result.Status,
+        Message = result.Message,
+        Location = result.Location,
+        ValidationErrors = result.ValidationErrors
+    };
+
+    /// <summary>
     /// Creates a successful result.
     /// </summary>
     /// <returns>A successful result.</returns>
@@ -121,6 +134,19 @@ public sealed class Result : IResult
     {
         Status = ResultStatus.Accepted,
         Message = message
+    };
+
+    /// <summary>
+    /// Creates a result indicating the request has been accepted for processing with a message and location.
+    /// </summary>
+    /// <param name="message">A message describing the accepted request.</param>
+    /// <param name="location">The location for tracking the accepted request (e.g. a job ID or status URL).</param>
+    /// <returns>A result with Accepted status, message, and location.</returns>
+    public static Result Accepted(string message, string location) => new()
+    {
+        Status = ResultStatus.Accepted,
+        Message = message,
+        Location = location
     };
 
     /// <summary>

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -978,7 +978,7 @@ internal static class EndpointGenerator
                 Foundatio.Mediator.ResultStatus.Created => Microsoft.AspNetCore.Http.Results.Created(
                     result.Location ?? "", result.GetValue()),
                 Foundatio.Mediator.ResultStatus.Accepted => Microsoft.AspNetCore.Http.Results.Accepted(
-                    null, result.GetValue()),
+                    string.IsNullOrEmpty(result.Location) ? null : result.Location, result.GetValue()),
                 Foundatio.Mediator.ResultStatus.NoContent => Microsoft.AspNetCore.Http.Results.NoContent(),
                 Foundatio.Mediator.ResultStatus.BadRequest => Microsoft.AspNetCore.Http.Results.BadRequest(
                     string.IsNullOrEmpty(result.Message) ? null : new { message = result.Message }),

--- a/src/Foundatio.Mediator/HandlerGenerator.cs
+++ b/src/Foundatio.Mediator/HandlerGenerator.cs
@@ -436,11 +436,30 @@ internal static class HandlerGenerator
             source.AppendLine("};");
         }
 
-        // Execute the outermost delegate and cast result
+        // Execute the outermost delegate and safely convert the result.
+        // Execute middleware returns object? — the actual type may differ from the handler's
+        // declared return type (e.g. middleware may return a non-generic Result while the
+        // handler declares Result<T>). We use a safe conversion instead of a hard cast.
         string finalDelegate = reversed.Count > 0 ? $"wrapped{reversed.Count - 1}" : "pipelineDelegate";
         if (handler.HasReturnValue)
         {
-            source.AppendLine($"{resultVar} = ({handler.ReturnType.UnwrappedFullName})(await {finalDelegate}())!;");
+            if (handler.ReturnType.IsResult)
+            {
+                // Handler returns Result or Result<T> — safe conversion from any IResult
+                // (preserves Status, Message, Location, ValidationErrors)
+                source.AppendLine($"var __executeRaw = await {finalDelegate}();");
+                source.AppendLine($"if (__executeRaw is {handler.ReturnType.UnwrappedFullName} __executeTyped)");
+                source.AppendLine($"    {resultVar} = __executeTyped;");
+                source.AppendLine($"else if (__executeRaw is Foundatio.Mediator.IResult __executeResult)");
+                source.AppendLine($"    {resultVar} = {handler.ReturnType.UnwrappedFullName}.FromResult(__executeResult);");
+                source.AppendLine($"else if (__executeRaw is not null)");
+                source.AppendLine($"    throw new System.InvalidOperationException($\"Execute middleware returned {{__executeRaw.GetType().Name}}, expected {handler.ReturnType.UnwrappedFullName}\");");
+            }
+            else
+            {
+                // Non-Result return types (tuples, raw types) — direct cast
+                source.AppendLine($"{resultVar} = ({handler.ReturnType.UnwrappedFullName})(await {finalDelegate}())!;");
+            }
         }
         else
         {
@@ -595,7 +614,6 @@ internal static class HandlerGenerator
             return;
 
         source.AppendLine();
-        source.AppendLine("// Authorization check (skipped for publish/event dispatch)");
         source.AppendLine("if (!skipAuthorization)");
         source.AppendLine("{");
         source.IncrementIndent();

--- a/tests/Foundatio.Mediator.Tests/BasicHandlerGenerationTests.EndpointGeneration.verified.txt
+++ b/tests/Foundatio.Mediator.Tests/BasicHandlerGenerationTests.EndpointGeneration.verified.txt
@@ -180,7 +180,7 @@ public static class MediatorEndpointResultMapper_Tests
             Foundatio.Mediator.ResultStatus.Created => Microsoft.AspNetCore.Http.Results.Created(
                 result.Location ?? "", result.GetValue()),
             Foundatio.Mediator.ResultStatus.Accepted => Microsoft.AspNetCore.Http.Results.Accepted(
-                null, result.GetValue()),
+                string.IsNullOrEmpty(result.Location) ? null : result.Location, result.GetValue()),
             Foundatio.Mediator.ResultStatus.NoContent => Microsoft.AspNetCore.Http.Results.NoContent(),
             Foundatio.Mediator.ResultStatus.BadRequest => Microsoft.AspNetCore.Http.Results.BadRequest(
                 string.IsNullOrEmpty(result.Message) ? null : new { message = result.Message }),

--- a/tests/Foundatio.Mediator.Tests/Integration/E2E_EndpointCallContextTests.cs
+++ b/tests/Foundatio.Mediator.Tests/Integration/E2E_EndpointCallContextTests.cs
@@ -175,4 +175,34 @@ public class E2E_EndpointCallContextTests(ITestOutputHelper output) : TestWithLo
         var result = await response.Content.ReadFromJsonAsync<string>(TestCancellationToken);
         Assert.Equal("test-user", result);
     }
+
+    // ── Result.Accepted with Location header ──────────────────────────────
+
+    public record CreateExportJob(string Name);
+
+    public class ExportJobHandler
+    {
+        public Result<string> Handle(CreateExportJob command)
+            => Result<string>.Accepted("Export queued", "/api/exports/status/job-123");
+    }
+
+    [Fact]
+    public async Task Endpoint_ResultAcceptedWithLocation_Returns202WithLocationHeader()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMediator(b => b.AddAssembly<ExportJobHandler>());
+
+        await using var app = builder.Build();
+        app.MapMediatorEndpoints();
+        await app.StartAsync(TestCancellationToken);
+
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync(
+            "/api/export-jobs", new { Name = "Q1 Report" }, TestCancellationToken);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal("/api/exports/status/job-123", response.Headers.Location?.ToString());
+    }
 }

--- a/tests/Foundatio.Mediator.Tests/Integration/LoggingIntegrationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/Integration/LoggingIntegrationTests.cs
@@ -13,13 +13,13 @@ public class LoggingIntegrationTests(ITestOutputHelper output) : TestWithLogging
     {
         // Arrange: register mediator with a debug-level logger to ensure logging
         // infrastructure doesn't interfere with handler dispatch
-        var services = new ServiceCollection()
-            .AddLogging(b =>
+        var services = new ServiceCollection();
+        services.AddLogging(b =>
             {
                 b.SetMinimumLevel(LogLevel.Debug);
                 b.AddTestLogger(_output);
-            })
-            .AddMediator();
+            });
+        services.AddMediator();
 
         using var serviceProvider = services.BuildServiceProvider();
         var mediator = serviceProvider.GetRequiredService<IMediator>();
@@ -38,13 +38,13 @@ public class LoggingIntegrationTests(ITestOutputHelper output) : TestWithLogging
     [Fact]
     public async Task Handler_InvokeAsync_Works_With_Logging_Configured()
     {
-        var services = new ServiceCollection()
-            .AddLogging(b =>
+        var services = new ServiceCollection();
+        services.AddLogging(b =>
             {
                 b.SetMinimumLevel(LogLevel.Trace);
                 b.AddTestLogger(_output);
-            })
-            .AddMediator();
+            });
+        services.AddMediator();
 
         await using var serviceProvider = services.BuildServiceProvider();
         var mediator = serviceProvider.GetRequiredService<IMediator>();


### PR DESCRIPTION
## Summary

Extracts core library improvements from the `queues` branch into a standalone PR. These are broadly useful changes with no queue-specific dependencies.

### Changes

1. **`IMediatorBuilder` fluent builder** — `AddMediator()` now returns `IMediatorBuilder` instead of `IServiceCollection`, enabling fluent chaining like `services.AddMediator().AddQueues()` for extension packages.

2. **`Result.Accepted(message, location)`** — New overload on both `Result` and `Result<T>` that accepts a location string (e.g., a job status URL). Also adds `Result.FromResult(IResult)` for safe cross-type conversion.

3. **Endpoint generator: Location header on Accepted** — `Results.Accepted()` now passes `result.Location` instead of `null`, so handlers returning `Result.Accepted("msg", "/status/123")` produce a proper HTTP `Location` header.

4. **Handler generator: safe Result conversion** — When Execute middleware returns a different `IResult` type than the handler declares (e.g., `Result` vs `Result<T>`), generated code now does a safe type check and `FromResult()` conversion instead of a hard cast that would throw `InvalidCastException`.

### Test coverage

- New integration test `Endpoint_ResultAcceptedWithLocation_Returns202WithLocationHeader` verifies HTTP 202 + Location header
- Updated endpoint generation snapshot
- All 598 tests pass