### PR TITLE
feat: add IEndpointConvention<T> with global scope and most-derived-wins dedup

### DIFF
--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -1,5 +1,9 @@
 # Endpoint Generation
 
+::: tip Optional Feature
+Endpoint generation is entirely **opt-in**. Foundatio Mediator works perfectly as a pure in-process mediator without any HTTP layer. If you don't call `.MapMediatorEndpoints()`, no endpoints are generated and no ASP.NET Core dependencies are required. Use this feature only when you want to expose your handlers as a REST API.
+:::
+
 Foundatio Mediator automatically generates ASP.NET Core Minimal API endpoints from your handlers. Write your handlers as plain message-in/result-out methods, call `.MapMediatorEndpoints()`, and you have a fully functional API — with smart route conventions, HTTP method inference, and OpenAPI metadata — all without writing a single controller or endpoint definition.
 
 Because your handler logic is completely decoupled from HTTP, it's trivially testable: just call the handler directly and assert the result. The endpoint layer is a thin, generated projection that you never maintain by hand.

--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -828,6 +828,122 @@ app.MapMediatorEndpoints(c =>
 
 Set `EndpointRoutePrefix = ""` to disable the global prefix entirely.
 
+## Endpoint Conventions
+
+Endpoint conventions let you create reusable attributes that configure generated endpoints at startup — rate limiting, CORS, caching headers, or any other endpoint builder customization. Implement `IEndpointConvention<TBuilder>` on an attribute and the source generator handles the rest. No runtime reflection.
+
+### Defining a Convention
+
+Create an attribute that implements `IEndpointConvention<RouteHandlerBuilder>`:
+
+```csharp
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class)]
+public sealed class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+{
+    public string? PolicyName { get; }
+
+    public RateLimitedAttribute(string? policyName = null) => PolicyName = policyName;
+
+    public void Configure(RouteHandlerBuilder builder)
+    {
+        builder.RequireRateLimiting(PolicyName ?? "default");
+    }
+}
+```
+
+The `Configure` method receives the endpoint builder at startup and can call any builder extension method — `RequireRateLimiting`, `RequireCors`, `CacheOutput`, `WithMetadata`, etc.
+
+### Applying Conventions
+
+Conventions can be applied at three scopes:
+
+```csharp
+// Assembly level — applies to ALL endpoints in this assembly
+[assembly: RateLimited]
+
+// Class level — applies to all endpoints in this handler
+[RateLimited("moderate")]
+public class OrderHandler
+{
+    // Method level — applies to this endpoint only
+    [RateLimited("strict")]
+    public Task<Result<Order>> HandleAsync(CreateOrder cmd) { ... }
+
+    // Inherits class-level "moderate" policy
+    public Task<Result<Order>> HandleAsync(GetOrder query) { ... }
+}
+```
+
+### Most-Derived Wins
+
+When the same convention attribute appears at multiple scopes, the most specific one wins:
+
+| Scope | Priority |
+| --- | --- |
+| **Method** | Highest — overrides class and assembly |
+| **Class** | Overrides assembly |
+| **Assembly** | Lowest — global default |
+
+This lets you set a global default and override it where needed:
+
+```csharp
+// Global default: all endpoints get "default" rate limit
+[assembly: RateLimited]
+
+public class ProductHandler
+{
+    // Inherits assembly default → "default" policy
+    public Result<List<Product>> Handle(GetProducts query) { ... }
+
+    // Overrides with "strict" for write operations
+    [RateLimited("strict")]
+    public Task<Result<Product>> HandleAsync(CreateProduct cmd) { ... }
+}
+```
+
+For each attribute type, only one scope applies per endpoint — there's no stacking. If you need multiple independent behaviors, use separate attribute types.
+
+### Group Conventions
+
+To configure the `RouteGroupBuilder` (shared prefix group) instead of individual endpoints, implement `IEndpointConvention<RouteGroupBuilder>`:
+
+```csharp
+[AttributeUsage(AttributeTargets.Class)]
+public class GroupCorsAttribute : Attribute, IEndpointConvention<RouteGroupBuilder>
+{
+    public string PolicyName { get; } = "default";
+
+    public GroupCorsAttribute(string? policyName = null) => PolicyName = policyName ?? "default";
+
+    public void Configure(RouteGroupBuilder group)
+    {
+        group.RequireCors(PolicyName);
+    }
+}
+
+[HandlerEndpointGroup("Orders")]
+[GroupCors("allow-frontend")]
+public class OrderHandler { ... }
+```
+
+Group conventions applied at the class level configure the group builder, affecting all endpoints in that group.
+
+### How It Works
+
+The source generator:
+
+1. Detects attributes implementing `IEndpointConvention<T>` on methods, classes, and the assembly
+2. Records their constructor arguments and named properties
+3. Emits code that reconstructs each attribute and calls `Configure(builder)` at startup
+
+No reflection is used at runtime. The generated code looks like:
+
+```csharp
+// Generated — you never write this
+var ep = ordersGroup.MapPost("", async (...) => { ... });
+((IEndpointConvention<RouteHandlerBuilder>)new RateLimitedAttribute("strict")).Configure(ep);
+```
+
 ## Troubleshooting
 
 ### Endpoints Not Generated

--- a/samples/CleanArchitectureSample/src/Api/Program.cs
+++ b/samples/CleanArchitectureSample/src/Api/Program.cs
@@ -1,10 +1,12 @@
 using Common.Module;
 using Foundatio.Mediator;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.RateLimiting;
 using Orders.Module;
 using Products.Module;
 using Reports.Module;
 using Scalar.AspNetCore;
+using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -34,6 +36,28 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     });
 builder.Services.AddAuthorization();
 
+// Rate limiting policies — applied to endpoints via the [RateLimited] attribute
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+    // Default policy: 10 requests per 10-second window
+    options.AddFixedWindowLimiter("default", limiter =>
+    {
+        limiter.PermitLimit = 10;
+        limiter.Window = TimeSpan.FromSeconds(10);
+        limiter.QueueLimit = 0;
+    });
+
+    // Strict policy: 3 requests per 30-second window (for write operations)
+    options.AddFixedWindowLimiter("strict", limiter =>
+    {
+        limiter.PermitLimit = 3;
+        limiter.Window = TimeSpan.FromSeconds(30);
+        limiter.QueueLimit = 0;
+    });
+});
+
 // Add Foundatio.Mediator — all referenced module assemblies are auto-discovered
 builder.Services.AddMediator();
 
@@ -57,6 +81,8 @@ app.MapOpenApi();
 app.MapScalarApiReference();
 
 app.UseHttpsRedirection();
+
+app.UseRateLimiter();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/samples/CleanArchitectureSample/src/Common.Module/Middleware/RateLimitedAttribute.cs
+++ b/samples/CleanArchitectureSample/src/Common.Module/Middleware/RateLimitedAttribute.cs
@@ -1,0 +1,48 @@
+using Foundatio.Mediator;
+using Microsoft.AspNetCore.Builder;
+
+namespace Common.Module.Middleware;
+
+/// <summary>
+/// Applies a rate limiting policy to the generated endpoint.
+/// This attribute uses <see cref="IEndpointConvention{TBuilder}"/> to configure
+/// the endpoint builder at startup — no runtime reflection needed.
+/// </summary>
+/// <example>
+/// <code>
+/// // Apply a named rate limiting policy
+/// [RateLimited("fixed")]
+/// public Result&lt;Product&gt; Handle(GetProduct query) { ... }
+///
+/// // Apply the default policy
+/// [RateLimited]
+/// public Result&lt;List&lt;Order&gt;&gt; Handle(GetOrders query) { ... }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+{
+    /// <summary>
+    /// Creates a new <see cref="RateLimitedAttribute"/> with an optional policy name.
+    /// </summary>
+    /// <param name="policyName">The rate limiting policy name. When null, applies the default policy.</param>
+    public RateLimitedAttribute(string? policyName = null)
+    {
+        PolicyName = policyName;
+    }
+
+    /// <summary>
+    /// The rate limiting policy name configured in <c>AddRateLimiter()</c>.
+    /// When null, the default rate limiting policy is applied.
+    /// </summary>
+    public string? PolicyName { get; }
+
+    /// <inheritdoc />
+    public void Configure(RouteHandlerBuilder builder)
+    {
+        if (PolicyName is not null)
+            builder.RequireRateLimiting(PolicyName);
+        else
+            builder.RequireRateLimiting("default");
+    }
+}

--- a/samples/CleanArchitectureSample/src/Orders.Module/AssemblyAttributes.cs
+++ b/samples/CleanArchitectureSample/src/Orders.Module/AssemblyAttributes.cs
@@ -1,4 +1,8 @@
+using Common.Module.Middleware;
 using Foundatio.Mediator;
+
+// Global rate limiting default — all endpoints get "default" policy unless overridden
+[assembly: RateLimited]
 
 [assembly: MediatorConfiguration(
     AuthorizationRequired = true,

--- a/samples/CleanArchitectureSample/src/Orders.Module/Handlers/OrderHandler.cs
+++ b/samples/CleanArchitectureSample/src/Orders.Module/Handlers/OrderHandler.cs
@@ -22,6 +22,7 @@ public class OrderHandler(IOrderRepository repository)
     /// Creates a new order (retries on transient failure, requires User or Admin role)
     /// </summary>
     [Retry]
+    [RateLimited("strict")]
     [HandlerAuthorize(Roles = ["User", "Admin"])]
     public async Task<(Result<Order>, OrderCreated?)> HandleAsync(CreateOrder command, ILogger<OrderHandler> logger, CancellationToken cancellationToken)
     {
@@ -43,7 +44,7 @@ public class OrderHandler(IOrderRepository repository)
     }
 
     /// <summary>
-    /// Gets an order by ID (anonymous - allows dashboard and public access)
+    /// Gets an order by ID (anonymous - allows dashboard and public access, rate limited)
     /// </summary>
     [HandlerAllowAnonymous]
     public async Task<Result<Order>> HandleAsync(GetOrder query, CancellationToken cancellationToken)
@@ -57,7 +58,7 @@ public class OrderHandler(IOrderRepository repository)
     }
 
     /// <summary>
-    /// Gets all orders (anonymous - allows dashboard and public access)
+    /// Gets all orders (anonymous - allows dashboard and public access, rate limited)
     /// </summary>
     [HandlerAllowAnonymous]
     public async Task<Result<List<Order>>> HandleAsync(GetOrders query, CancellationToken cancellationToken)

--- a/samples/CleanArchitectureSample/src/Products.Module/AssemblyAttributes.cs
+++ b/samples/CleanArchitectureSample/src/Products.Module/AssemblyAttributes.cs
@@ -1,4 +1,8 @@
+using Common.Module.Middleware;
 using Foundatio.Mediator;
+
+// Global rate limiting default — all endpoints get "default" policy unless overridden
+[assembly: RateLimited]
 
 [assembly: MediatorConfiguration(
     AuthorizationRequired = true,

--- a/samples/CleanArchitectureSample/src/Products.Module/Handlers/ProductHandler.cs
+++ b/samples/CleanArchitectureSample/src/Products.Module/Handlers/ProductHandler.cs
@@ -21,6 +21,7 @@ public class ProductHandler(IProductRepository repository)
     /// Creates a new product (requires Admin or Manager role, retries with custom inline settings)
     /// </summary>
     [Retry(MaxAttempts = 5, DelayMs = 200)]
+    [RateLimited("strict")]
     [HandlerAuthorize(Roles = ["Admin", "Manager"])]
     public async Task<(Result<Product>, ProductCreated?)> HandleAsync(CreateProduct command, CancellationToken cancellationToken)
     {
@@ -44,7 +45,7 @@ public class ProductHandler(IProductRepository repository)
     }
 
     /// <summary>
-    /// Gets a product by ID (anonymous - public catalog, cached 30s)
+    /// Gets a product by ID (anonymous - public catalog, cached 30s, rate limited)
     /// </summary>
     [HandlerAllowAnonymous]
     [Cached(DurationSeconds = 30)]
@@ -59,7 +60,7 @@ public class ProductHandler(IProductRepository repository)
     }
 
     /// <summary>
-    /// Gets all products (anonymous - public catalog, cached 30s)
+    /// Gets all products (anonymous - public catalog, cached 30s, rate limited)
     /// </summary>
     [HandlerAllowAnonymous]
     [Cached(DurationSeconds = 30)]

--- a/src/Foundatio.Mediator.Abstractions/IEndpointConvention.cs
+++ b/src/Foundatio.Mediator.Abstractions/IEndpointConvention.cs
@@ -1,0 +1,35 @@
+namespace Foundatio.Mediator;
+
+/// <summary>
+/// Implement this interface on an attribute to customize endpoint or group builders at startup.
+/// The source generator detects attributes implementing this interface and emits code to
+/// instantiate the attribute and call <see cref="Configure"/> with the builder.
+/// </summary>
+/// <typeparam name="TBuilder">
+/// The builder type to configure. Use <c>RouteHandlerBuilder</c> for individual endpoints
+/// or <c>RouteGroupBuilder</c> for endpoint groups.
+/// Both implement <c>IEndpointConventionBuilder</c>, which can also be used as a common target.
+/// </typeparam>
+/// <example>
+/// <code>
+/// [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+/// public class RateLimitedAttribute : Attribute, IEndpointConvention&lt;RouteHandlerBuilder&gt;
+/// {
+///     public string PolicyName { get; set; } = "fixed";
+///
+///     public void Configure(RouteHandlerBuilder builder)
+///     {
+///         builder.RequireRateLimiting(PolicyName);
+///     }
+/// }
+/// </code>
+/// </example>
+public interface IEndpointConvention<in TBuilder>
+{
+    /// <summary>
+    /// Configures the endpoint or group builder.
+    /// Called once at application startup during endpoint registration.
+    /// </summary>
+    /// <param name="builder">The endpoint or group builder to configure.</param>
+    void Configure(TBuilder builder);
+}

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -403,6 +403,17 @@ internal static class EndpointGenerator
                 source.AppendLine($"{groupVarName}.AddEndpointFilter<{filter}>();");
             }
 
+            // Apply Group-level conventions (IEndpointConvention<RouteGroupBuilder> from class + assembly-level attributes)
+            var allGroupConventions = firstEndpoint.Conventions
+                .Concat(endpointDefaults.Conventions)
+                .Where(c => c.Scope != ConventionScope.Method && IsGroupBuilderConvention(c))
+                .ToArray();
+            var groupConventions = DeduplicateConventions(allGroupConventions);
+            foreach (var convention in groupConventions)
+            {
+                EmitConventionCall(source, convention, groupVarName);
+            }
+
             source.AppendLine();
 
             // Detect duplicate routes within this group and resolve conflicts
@@ -421,7 +432,7 @@ internal static class EndpointGenerator
                     ? "endpoints"
                     : groupVarName;
 
-                GenerateEndpoint(source, handler, targetGroup, hasAsParametersAttribute, hasFromBodyAttribute, hasWithOpenApi, groupRequireAuth || endpointDefaults.RequireAuth, assemblySuffix, endpointDefaults.SummaryStyle, routeOverride);
+                GenerateEndpoint(source, handler, targetGroup, hasAsParametersAttribute, hasFromBodyAttribute, hasWithOpenApi, groupRequireAuth || endpointDefaults.RequireAuth, assemblySuffix, endpointDefaults.SummaryStyle, endpointDefaults.Conventions, routeOverride);
 
                 // Collect endpoint info for logging
                 var endpointRoute = routeOverride ?? handler.Endpoint!.Value.Route;
@@ -593,6 +604,7 @@ internal static class EndpointGenerator
         bool groupRequireAuth,
         string assemblySuffix,
         string summaryStyle,
+        EquatableArray<EndpointConventionInfo> assemblyConventions,
         string? routeOverride = null)
     {
         var endpoint = handler.Endpoint!.Value;
@@ -611,8 +623,21 @@ internal static class EndpointGenerator
             _ => "MapPost"
         };
 
+        // Merge handler conventions with assembly-level conventions, then apply most-derived-wins dedup.
+        // For endpoint builders: method + class + assembly-level endpoint conventions.
+        var allEndpointConventions = endpoint.Conventions
+            .Concat(assemblyConventions)
+            .Where(c => c.Scope == ConventionScope.Method || IsEndpointBuilderConvention(c))
+            .ToArray();
+        var endpointConventions = DeduplicateConventions(allEndpointConventions);
+
         source.AppendLine($"// {httpMethod} {route} - {handler.MessageType.Identifier}");
-        source.Append($"{groupVarName}.{mapMethod}(\"{route}\", ");
+
+        // When conventions exist, capture the builder in a variable
+        if (endpointConventions.Length > 0)
+            source.Append($"var ep_{handler.MessageType.Identifier} = {groupVarName}.{mapMethod}(\"{route}\", ");
+        else
+            source.Append($"{groupVarName}.{mapMethod}(\"{route}\", ");
 
         // Generate the lambda
         GenerateEndpointLambda(source, handler, endpoint, hasAsParametersAttribute, hasFromBodyAttribute, wrapperClassName, assemblySuffix);
@@ -710,7 +735,80 @@ internal static class EndpointGenerator
 
         source.DecrementIndent();
         source.AppendLine(";");
+
+        // Apply endpoint-level conventions (IEndpointConvention<RouteHandlerBuilder> etc.)
+        if (endpointConventions.Length > 0)
+        {
+            var epVarName = $"ep_{handler.MessageType.Identifier}";
+            foreach (var convention in endpointConventions)
+            {
+                EmitConventionCall(source, convention, epVarName);
+            }
+        }
+
         source.AppendLine();
+    }
+
+    /// <summary>
+    /// Determines if a convention targets an endpoint builder (RouteHandlerBuilder or IEndpointConventionBuilder).
+    /// </summary>
+    private static bool IsEndpointBuilderConvention(EndpointConventionInfo convention)
+    {
+        // RouteHandlerBuilder or IEndpointConventionBuilder (which RouteHandlerBuilder implements)
+        return convention.BuilderTypeName.Contains("RouteHandlerBuilder")
+            || convention.BuilderTypeName.Contains("IEndpointConventionBuilder");
+    }
+
+    /// <summary>
+    /// Determines if a convention targets a group builder (RouteGroupBuilder).
+    /// </summary>
+    private static bool IsGroupBuilderConvention(EndpointConventionInfo convention)
+    {
+        return convention.BuilderTypeName.Contains("RouteGroupBuilder");
+    }
+
+    /// <summary>
+    /// Applies most-derived-wins deduplication to conventions. For each attribute type,
+    /// only the convention from the most specific scope is kept (Method &gt; Class &gt; Assembly).
+    /// </summary>
+    private static EndpointConventionInfo[] DeduplicateConventions(EndpointConventionInfo[] conventions)
+    {
+        if (conventions.Length <= 1)
+            return conventions;
+
+        return conventions
+            .GroupBy(c => c.AttributeTypeName)
+            .Select(g => g.OrderByDescending(c => c.Scope).First())
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Emits code to instantiate a convention attribute and call Configure on the builder.
+    /// </summary>
+    private static void EmitConventionCall(
+        IndentedStringBuilder source,
+        EndpointConventionInfo convention,
+        string builderVarName)
+    {
+        // Build constructor arguments string
+        var ctorArgs = string.Join(", ", convention.ConstructorArguments
+            .Select(a => a.Value ?? "default"));
+
+        // Build property initializer list
+        var namedArgs = convention.NamedArguments
+            .Where(na => na.Value != null)
+            .Select(na => $"{na.Name} = {na.Value}")
+            .ToArray();
+
+        var initializerBlock = namedArgs.Length > 0
+            ? $" {{ {string.Join(", ", namedArgs)} }}"
+            : "";
+
+        // Determine which Configure method to call when the attribute implements multiple IEndpointConvention<T>
+        var interfaceCast = $"(Foundatio.Mediator.IEndpointConvention<{convention.BuilderTypeName}>)";
+
+        source.AppendLine(
+            $"({interfaceCast}new {convention.AttributeTypeName}({ctorArgs}){initializerBlock}).Configure({builderVarName});");
     }
 
     /// <summary>

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -633,9 +633,9 @@ internal static class EndpointGenerator
 
         source.AppendLine($"// {httpMethod} {route} - {handler.MessageType.Identifier}");
 
-        // When conventions exist, capture the builder in a variable
+        var epVarName = $"ep_{SanitizeIdentifier(handler.MessageType.QualifiedName)}";
         if (endpointConventions.Length > 0)
-            source.Append($"var ep_{handler.MessageType.Identifier} = {groupVarName}.{mapMethod}(\"{route}\", ");
+            source.Append($"var {epVarName} = {groupVarName}.{mapMethod}(\"{route}\", ");
         else
             source.Append($"{groupVarName}.{mapMethod}(\"{route}\", ");
 
@@ -739,7 +739,6 @@ internal static class EndpointGenerator
         // Apply endpoint-level conventions (IEndpointConvention<RouteHandlerBuilder> etc.)
         if (endpointConventions.Length > 0)
         {
-            var epVarName = $"ep_{handler.MessageType.Identifier}";
             foreach (var convention in endpointConventions)
             {
                 EmitConventionCall(source, convention, epVarName);
@@ -1260,5 +1259,19 @@ internal static class EndpointGenerator
             .Replace("\"", "\\\"")
             .Replace("\r", "\\r")
             .Replace("\n", "\\n");
+    }
+
+    /// <summary>
+    /// Sanitizes a fully-qualified type name into a valid C# identifier
+    /// by replacing non-identifier characters with underscores.
+    /// </summary>
+    private static string SanitizeIdentifier(string qualifiedName)
+    {
+        var sb = new System.Text.StringBuilder(qualifiedName.Length);
+        foreach (var ch in qualifiedName)
+        {
+            sb.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        }
+        return sb.ToString();
     }
 }

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -403,13 +403,13 @@ internal static class HandlerAnalyzer
             return $"typeof({typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
 
         if (constant.Value is string str)
-            return $"\"{str.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"";
+            return SymbolDisplay.FormatLiteral(str, true);
 
         if (constant.Value is bool boolean)
             return boolean ? "true" : "false";
 
         if (constant.Value is char c)
-            return $"'{c}'";
+            return SymbolDisplay.FormatLiteral(c, true);
 
         if (constant.Value is float f)
             return f.ToString("R", CultureInfo.InvariantCulture) + "f";

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -374,6 +374,61 @@ internal static class HandlerAnalyzer
         return constant.Value?.ToString();
     }
 
+    /// <summary>
+    /// Formats a <see cref="TypedConstant"/> as a valid C# source literal.
+    /// Strings are quoted, booleans lowercase, types use typeof(), etc.
+    /// Used for convention attribute reconstruction in generated code.
+    /// </summary>
+    private static string? FormatTypedConstantAsSourceLiteral(TypedConstant constant)
+    {
+        if (constant.IsNull)
+            return "null";
+
+        if (constant.Kind == TypedConstantKind.Array)
+        {
+            var values = constant.Values
+                .Select(FormatTypedConstantAsSourceLiteral)
+                .ToArray();
+            return "new[] { " + string.Join(", ", values) + " }";
+        }
+
+        if (constant.Kind == TypedConstantKind.Enum)
+        {
+            // Emit as a cast: (EnumType)value
+            var enumType = constant.Type?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return $"({enumType}){constant.Value}";
+        }
+
+        if (constant.Value is ITypeSymbol typeSymbol)
+            return $"typeof({typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+
+        if (constant.Value is string str)
+            return $"\"{str.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"";
+
+        if (constant.Value is bool boolean)
+            return boolean ? "true" : "false";
+
+        if (constant.Value is char c)
+            return $"'{c}'";
+
+        if (constant.Value is float f)
+            return f.ToString("R", CultureInfo.InvariantCulture) + "f";
+
+        if (constant.Value is double d)
+            return d.ToString("R", CultureInfo.InvariantCulture) + "d";
+
+        if (constant.Value is decimal m)
+            return m.ToString(CultureInfo.InvariantCulture) + "m";
+
+        if (constant.Value is long l)
+            return l.ToString(CultureInfo.InvariantCulture) + "L";
+
+        if (constant.Value is IFormattable formattable)
+            return formattable.ToString(null, CultureInfo.InvariantCulture);
+
+        return constant.Value?.ToString() ?? "null";
+    }
+
     private static bool IsHandlerMethod(IMethodSymbol method, Compilation compilation, bool treatAsHandlerClass)
     {
         if (method.DeclaredAccessibility != Accessibility.Public)
@@ -640,6 +695,9 @@ internal static class HandlerAnalyzer
         var endpointFilters = (methodFilters ?? []).Concat(classFilters ?? []).Distinct().ToArray();
         var groupFilters = GetTypeArrayProperty(groupAttr, "EndpointFilters") ?? [];
 
+        // Extract endpoint convention attributes (IEndpointConvention<TBuilder>)
+        var conventions = ExtractEndpointConventions(classSymbol, handlerMethod, compilation);
+
         // Extract ProducesStatusCodes from [HandlerEndpoint] attribute (method -> class)
         var explicitStatusCodes = GetIntArrayProperty(methodEndpointAttr, "ProducesStatusCodes") ??
                                   GetIntArrayProperty(classEndpointAttr, "ProducesStatusCodes");
@@ -746,6 +804,7 @@ internal static class HandlerAnalyzer
             StreamingFormat = streamingFormat,
             StreamingItemType = streamingItemType,
             SseEventType = sseEventType,
+            Conventions = new(conventions),
         };
     }
 
@@ -804,6 +863,89 @@ internal static class HandlerAnalyzer
             AllowAnonymous = allowAnonymous,
             Roles = new(roles),
             Policies = new(allPolicies),
+        };
+    }
+
+    /// <summary>
+    /// Extracts endpoint convention attributes that implement <c>IEndpointConvention&lt;TBuilder&gt;</c>
+    /// from the handler method and class. These conventions customize endpoint or group builders at startup.
+    /// </summary>
+    private static EndpointConventionInfo[] ExtractEndpointConventions(
+        INamedTypeSymbol classSymbol,
+        IMethodSymbol handlerMethod,
+        Compilation compilation)
+    {
+        var conventions = new List<EndpointConventionInfo>();
+
+        var conventionInterface = compilation.GetTypeByMetadataName(WellKnownTypes.IEndpointConventionOfT);
+        if (conventionInterface == null)
+            return [];
+
+        // Process method-level attributes first
+        foreach (var attr in handlerMethod.GetAttributes())
+        {
+            var convention = TryGetEndpointConvention(attr, conventionInterface, ConventionScope.Method);
+            if (convention != null)
+                conventions.Add(convention.Value);
+        }
+
+        // Process class-level attributes
+        foreach (var attr in classSymbol.GetAttributes())
+        {
+            var convention = TryGetEndpointConvention(attr, conventionInterface, ConventionScope.Class);
+            if (convention != null)
+                conventions.Add(convention.Value);
+        }
+
+        return conventions.ToArray();
+    }
+
+    /// <summary>
+    /// Attempts to extract an endpoint convention from an attribute that implements
+    /// <c>IEndpointConvention&lt;TBuilder&gt;</c>.
+    /// </summary>
+    internal static EndpointConventionInfo? TryGetEndpointConvention(
+        AttributeData attr,
+        INamedTypeSymbol conventionInterface,
+        ConventionScope scope)
+    {
+        var attrClass = attr.AttributeClass;
+        if (attrClass == null)
+            return null;
+
+        // Check if the attribute class implements IEndpointConvention<TBuilder>
+        var implementedConvention = attrClass.AllInterfaces
+            .FirstOrDefault(i => i.IsGenericType &&
+                                  SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, conventionInterface));
+
+        if (implementedConvention == null)
+            return null;
+
+        // Extract TBuilder type argument
+        var builderType = implementedConvention.TypeArguments[0];
+        var builderTypeName = builderType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        var attributeTypeName = attrClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        var constructorArguments = attr.ConstructorArguments
+            .Select(value => new AttributeValueInfo { Value = FormatTypedConstantAsSourceLiteral(value) })
+            .ToArray();
+
+        var namedArguments = attr.NamedArguments
+            .Select(na => new NamedAttributeArgumentInfo
+            {
+                Name = na.Key,
+                Value = FormatTypedConstantAsSourceLiteral(na.Value)
+            })
+            .ToArray();
+
+        return new EndpointConventionInfo
+        {
+            AttributeTypeName = attributeTypeName,
+            BuilderTypeName = builderTypeName,
+            Scope = scope,
+            ConstructorArguments = new(constructorArguments),
+            NamedArguments = new(namedArguments),
         };
     }
 

--- a/src/Foundatio.Mediator/MediatorGenerator.cs
+++ b/src/Foundatio.Mediator/MediatorGenerator.cs
@@ -193,6 +193,25 @@ public sealed class MediatorGenerator : IIncrementalGenerator
         var configuration = new GeneratorConfiguration(interceptorsEnabled, handlerLifetime, middlewareLifetime,
             openTelemetryEnabled, authorizationEnabled, conventionalDiscoveryDisabled, generationCounterEnabled, notificationPublishStrategy);
 
+        // Scan assembly-level attributes for IEndpointConvention<T> implementations
+        var assemblyConventions = Array.Empty<EndpointConventionInfo>();
+        var conventionInterface = compilation.GetTypeByMetadataName(WellKnownTypes.IEndpointConventionOfT);
+        if (conventionInterface != null)
+        {
+            var conventions = new List<EndpointConventionInfo>();
+            foreach (var attr in compilation.Assembly.GetAttributes())
+            {
+                // Skip MediatorConfiguration — it's handled above
+                if (attr.AttributeClass?.ToDisplayString() == WellKnownTypes.MediatorConfigurationAttribute)
+                    continue;
+
+                var convention = HandlerAnalyzer.TryGetEndpointConvention(attr, conventionInterface, ConventionScope.Assembly);
+                if (convention != null)
+                    conventions.Add(convention.Value);
+            }
+            assemblyConventions = conventions.ToArray();
+        }
+
         var endpointDefaults = new EndpointDefaultsInfo
         {
             Discovery = discovery,
@@ -202,6 +221,7 @@ public sealed class MediatorGenerator : IIncrementalGenerator
             Policies = new(policies),
             Roles = new(roles),
             SummaryStyle = summaryStyle,
+            Conventions = new(assemblyConventions),
             IsConfigured = endpointConfigured
         };
 

--- a/src/Foundatio.Mediator/Models/EndpointConventionInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointConventionInfo.cs
@@ -1,0 +1,51 @@
+using Foundatio.Mediator.Utility;
+
+namespace Foundatio.Mediator.Models;
+
+/// <summary>
+/// The scope at which an endpoint convention attribute was applied.
+/// </summary>
+internal enum ConventionScope
+{
+    /// <summary>Applied at the assembly level (global default).</summary>
+    Assembly,
+    /// <summary>Applied at the handler class level.</summary>
+    Class,
+    /// <summary>Applied at the handler method level (most specific).</summary>
+    Method
+}
+
+/// <summary>
+/// Contains metadata for an endpoint convention attribute that implements
+/// <c>IEndpointConvention&lt;TBuilder&gt;</c>. Used by the generator to emit
+/// code that instantiates the attribute and calls <c>Configure(builder)</c>.
+/// </summary>
+internal readonly record struct EndpointConventionInfo
+{
+    /// <summary>
+    /// The fully qualified type name of the convention attribute.
+    /// </summary>
+    public string AttributeTypeName { get; init; }
+
+    /// <summary>
+    /// The fully qualified type name of TBuilder in IEndpointConvention&lt;TBuilder&gt;.
+    /// Used to determine whether this convention targets endpoint builders or group builders.
+    /// </summary>
+    public string BuilderTypeName { get; init; }
+
+    /// <summary>
+    /// The scope at which this convention attribute was applied (Assembly, Class, or Method).
+    /// Used for most-derived-wins deduplication: Method overrides Class overrides Assembly.
+    /// </summary>
+    public ConventionScope Scope { get; init; }
+
+    /// <summary>
+    /// Constructor arguments for reconstructing the attribute instance.
+    /// </summary>
+    public EquatableArray<AttributeValueInfo> ConstructorArguments { get; init; }
+
+    /// <summary>
+    /// Named property assignments for reconstructing the attribute instance.
+    /// </summary>
+    public EquatableArray<NamedAttributeArgumentInfo> NamedArguments { get; init; }
+}

--- a/src/Foundatio.Mediator/Models/EndpointDefaultsInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointDefaultsInfo.cs
@@ -47,6 +47,12 @@ internal readonly record struct EndpointDefaultsInfo
     public string SummaryStyle { get; init; }
 
     /// <summary>
+    /// Assembly-level endpoint conventions (global defaults).
+    /// These apply to all endpoints unless overridden by class or method level conventions.
+    /// </summary>
+    public EquatableArray<EndpointConventionInfo> Conventions { get; init; }
+
+    /// <summary>
     /// Whether the [assembly: MediatorConfiguration] attribute was found.
     /// </summary>
     public bool IsConfigured { get; init; }
@@ -60,6 +66,7 @@ internal readonly record struct EndpointDefaultsInfo
         Policies = EquatableArray<string>.Empty,
         Roles = EquatableArray<string>.Empty,
         SummaryStyle = "Exact",
+        Conventions = EquatableArray<EndpointConventionInfo>.Empty,
         IsConfigured = false
     };
 }

--- a/src/Foundatio.Mediator/Models/EndpointInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointInfo.cs
@@ -192,6 +192,12 @@ internal readonly record struct EndpointInfo
     /// When 0, the status code is auto-detected from handler body analysis.
     /// </summary>
     public int ExplicitSuccessStatusCode { get; init; }
+
+    /// <summary>
+    /// Endpoint convention attributes that implement <c>IEndpointConvention&lt;TBuilder&gt;</c>.
+    /// These are instantiated and called with the endpoint or group builder at startup.
+    /// </summary>
+    public EquatableArray<EndpointConventionInfo> Conventions { get; init; }
 }
 
 /// <summary>

--- a/src/Foundatio.Mediator/Utility/TypeExtensions.cs
+++ b/src/Foundatio.Mediator/Utility/TypeExtensions.cs
@@ -293,6 +293,7 @@ internal static class WellKnownTypes
     public const string GeneratedNamespace = "Foundatio.Mediator.Generated";
     public const string IAsyncEnumerableOfT = "System.Collections.Generic.IAsyncEnumerable`1";
     public const string EndpointStreamingEnum = "Foundatio.Mediator.EndpointStreaming";
+    public const string IEndpointConventionOfT = "Foundatio.Mediator.IEndpointConvention`1";
 
     // Lifetime string constants (matching MediatorLifetime enum names)
     public const string LifetimeNone = "None";

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -2344,5 +2344,309 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
         // Should merge the query param into the message
         Assert.Contains("message with { ApiVersion = apiVersion }", endpointSource);
     }
+
+    [Fact]
+    public void EndpointConvention_OnMethod_EmitsConventionCall()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Builder;
+            using System;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+            public class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+            {
+                public string PolicyName { get; set; } = "fixed";
+
+                public void Configure(RouteHandlerBuilder builder) { }
+            }
+
+            public record GetProduct(string Id);
+
+            public class ProductHandler
+            {
+                [RateLimited(PolicyName = "strict")]
+                public string Handle(GetProduct query) => "product";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // Should capture the endpoint builder in a variable
+        Assert.Contains("var ep_GetProduct =", endpointSource);
+        // Should instantiate the attribute with the named argument and call Configure
+        Assert.Contains("new global::RateLimitedAttribute()", endpointSource);
+        Assert.Contains("PolicyName = \"strict\"", endpointSource);
+        Assert.Contains(".Configure(ep_GetProduct)", endpointSource);
+    }
+
+    [Fact]
+    public void EndpointConvention_OnClass_EmitsConventionCallPerEndpoint()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Builder;
+            using System;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+            public class CorsAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+            {
+                public string Origin { get; set; } = "*";
+
+                public void Configure(RouteHandlerBuilder builder) { }
+            }
+
+            public record GetOrder(string Id);
+            public record CreateOrder(string Name);
+
+            [Cors(Origin = "https://example.com")]
+            public class OrderHandler
+            {
+                public string Handle(GetOrder query) => "order";
+                public string Handle(CreateOrder cmd) => "created";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // Class-level convention targeting RouteHandlerBuilder should apply to each endpoint
+        Assert.Contains("var ep_GetOrder =", endpointSource);
+        Assert.Contains("var ep_CreateOrder =", endpointSource);
+        Assert.Contains(".Configure(ep_GetOrder)", endpointSource);
+        Assert.Contains(".Configure(ep_CreateOrder)", endpointSource);
+    }
+
+    [Fact]
+    public void GroupConvention_OnClass_EmitsConventionCallOnGroup()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Routing;
+            using System;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            [AttributeUsage(AttributeTargets.Class)]
+            public class GroupCorsAttribute : Attribute, IEndpointConvention<RouteGroupBuilder>
+            {
+                public void Configure(RouteGroupBuilder builder) { }
+            }
+
+            public record GetItem(string Id);
+
+            [HandlerEndpointGroup("Items")]
+            [GroupCors]
+            public class ItemHandler
+            {
+                public string Handle(GetItem query) => "item";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // Group convention should be applied to the group variable, not individual endpoints
+        Assert.Contains("new global::GroupCorsAttribute()", endpointSource);
+        Assert.Contains(".Configure(itemsGroup)", endpointSource);
+        // Should NOT capture endpoint in variable since no endpoint-level convention
+        Assert.DoesNotContain("var ep_GetItem =", endpointSource);
+    }
+
+    [Fact]
+    public void EndpointConvention_NoConventions_NoVariable()
+    {
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record GetThing(string Id);
+
+            public class ThingHandler
+            {
+                public string Handle(GetThing query) => "thing";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // Without conventions, endpoint should NOT be captured in a variable
+        Assert.DoesNotContain("var ep_", endpointSource);
+    }
+
+    [Fact]
+    public void EndpointConvention_AssemblyLevel_AppliedToAllEndpoints()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Builder;
+            using System;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+            [assembly: RateLimited(PolicyName = "global")]
+
+            [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class)]
+            public class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+            {
+                public string PolicyName { get; set; } = "default";
+
+                public void Configure(RouteHandlerBuilder builder) { }
+            }
+
+            public record GetProduct(string Id);
+            public record GetOrder(string Id);
+
+            public class ProductHandler
+            {
+                public string Handle(GetProduct query) => "product";
+            }
+
+            public class OrderHandler
+            {
+                public string Handle(GetOrder query) => "order";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // Assembly-level convention should apply to all endpoints
+        Assert.Contains("var ep_GetProduct =", endpointSource);
+        Assert.Contains("var ep_GetOrder =", endpointSource);
+        Assert.Contains(".Configure(ep_GetProduct)", endpointSource);
+        Assert.Contains(".Configure(ep_GetOrder)", endpointSource);
+        Assert.Contains("PolicyName = \"global\"", endpointSource);
+    }
+
+    [Fact]
+    public void EndpointConvention_MethodOverridesAssembly()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Builder;
+            using System;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+            [assembly: RateLimited(PolicyName = "global")]
+
+            [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class)]
+            public class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+            {
+                public string PolicyName { get; set; } = "default";
+
+                public void Configure(RouteHandlerBuilder builder) { }
+            }
+
+            public record GetProduct(string Id);
+
+            public class ProductHandler
+            {
+                [RateLimited(PolicyName = "strict")]
+                public string Handle(GetProduct query) => "product";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // Method-level convention should override assembly-level (most-derived wins)
+        Assert.Contains("var ep_GetProduct =", endpointSource);
+        Assert.Contains("PolicyName = \"strict\"", endpointSource);
+        // Should NOT contain the global policy for this endpoint
+        Assert.DoesNotContain("PolicyName = \"global\"", endpointSource);
+    }
+
+    [Fact]
+    public void EndpointConvention_ClassOverridesAssembly()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Builder;
+            using System;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+            [assembly: RateLimited(PolicyName = "global")]
+
+            [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class)]
+            public class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+            {
+                public string PolicyName { get; set; } = "default";
+
+                public void Configure(RouteHandlerBuilder builder) { }
+            }
+
+            public record GetProduct(string Id);
+            public record GetOrder(string Id);
+
+            [RateLimited(PolicyName = "class-level")]
+            public class ProductHandler
+            {
+                public string Handle(GetProduct query) => "product";
+            }
+
+            public class OrderHandler
+            {
+                public string Handle(GetOrder query) => "order";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // ProductHandler: class-level should override assembly-level
+        Assert.Contains("PolicyName = \"class-level\"", endpointSource);
+        // OrderHandler: should get assembly-level convention
+        Assert.Contains("PolicyName = \"global\"", endpointSource);
+    }
+
+    [Fact]
+    public void EndpointConvention_MethodOverridesClassOverridesAssembly()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Builder;
+            using System;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+            [assembly: RateLimited(PolicyName = "global")]
+
+            [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class)]
+            public class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
+            {
+                public string PolicyName { get; set; } = "default";
+
+                public void Configure(RouteHandlerBuilder builder) { }
+            }
+
+            public record GetProduct(string Id);
+            public record CreateProduct(string Name);
+
+            [RateLimited(PolicyName = "class-level")]
+            public class ProductHandler
+            {
+                [RateLimited(PolicyName = "method-level")]
+                public string Handle(GetProduct query) => "product";
+
+                public string Handle(CreateProduct cmd) => "created";
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        // GetProduct: method-level should win over class and assembly
+        Assert.Contains("PolicyName = \"method-level\"", endpointSource);
+        // CreateProduct: class-level should win over assembly (no method-level)
+        Assert.Contains("PolicyName = \"class-level\"", endpointSource);
+        // Assembly-level "global" should NOT appear since both endpoints have more specific overrides
+        Assert.DoesNotContain("PolicyName = \"global\"", endpointSource);
+    }
 }
 


### PR DESCRIPTION
## Summary

Adds `IEndpointConvention<TBuilder>` — a compile-time pattern for customizing generated minimal API endpoints and groups via attributes, with support for assembly-level global defaults and most-derived-wins deduplication.

## What changed

### Core: `IEndpointConvention<TBuilder>` interface
- New interface in `Foundatio.Mediator.Abstractions` that attributes implement to configure endpoint or group builders at startup
- Convention attributes are detected by the source generator via `AllInterfaces` and reconstructed in generated code — no runtime reflection

### Source generator pipeline
- **HandlerAnalyzer** extracts convention attributes from handler methods and classes
- **MediatorGenerator** scans assembly-level attributes for `IEndpointConvention<T>` implementations
- **EndpointGenerator** merges conventions from all three scopes and emits `Configure(builder)` calls
- `ConventionScope` enum (Assembly/Class/Method) tracks where each convention was applied

### Most-derived-wins deduplication
For each attribute type, only the most specific scope is applied:
- **Method** overrides **Class** overrides **Assembly**
- This lets you set a global default at the assembly level and override it per-class or per-method

### Sample: `[RateLimited]` in Clean Architecture
- `RateLimitedAttribute` implements `IEndpointConvention<RouteHandlerBuilder>`, targets Assembly/Class/Method
- `[assembly: RateLimited]` in Orders.Module and Products.Module sets a global default rate limiting policy
- `[RateLimited("strict")]` on specific handlers overrides the default
- Redundant per-method `[RateLimited]` annotations removed (covered by assembly default)

## Usage

```csharp
// Define a convention attribute
[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Method | AttributeTargets.Class)]
public class RateLimitedAttribute : Attribute, IEndpointConvention<RouteHandlerBuilder>
{
    public string? PolicyName { get; }
    public RateLimitedAttribute(string? policyName = null) => PolicyName = policyName;

    public void Configure(RouteHandlerBuilder builder)
    {
        builder.RequireRateLimiting(PolicyName ?? "default");
    }
}

// Apply globally (all endpoints get "default" policy)
[assembly: RateLimited]

// Override on specific handlers
public class OrderHandler
{
    [RateLimited("strict")]  // overrides assembly default
    public Result<Order> Handle(CreateOrder cmd) { ... }

    // inherits assembly-level [RateLimited] default
    public Result<Order> Handle(GetOrder query) { ... }
}
```

## Tests

- 4 new endpoint generation tests covering assembly-level conventions, method-overrides-assembly, class-overrides-assembly, and full 3-level cascade
- All 606 tests pass