### PR TITLE
Add endpoint content type metadata

### DIFF
--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -235,7 +235,7 @@ All properties (including `Method` and `Route`) are also settable as named argum
 | `SuccessStatusCodes` | Override auto-detected success status codes (200, 201, 202, 204, etc.) |
 | `ProducesStatusCodes` | Explicit error status codes for OpenAPI (e.g., `[404, 400]`) |
 | `AcceptsContentTypes` | Request body content types for generated `.Accepts<T>()` metadata |
-| `ProducesContentTypes` | Success response content types for generated `.Produces<T>()` metadata |
+| `ProducesContentTypes` | Success response content types for generated `.Produces<T>()` metadata, or `.Produces()` metadata for file downloads |
 | `Streaming` | `EndpointStreaming.ServerSentEvents` for SSE; `Default` for JSON array |
 | `SseEventType` | SSE `event:` field name for `addEventListener` |
 
@@ -804,7 +804,10 @@ For example, `Result.Invalid()` uses ASP.NET Core's default `ValidationProblem` 
 ```csharp
 public class ReportHandler
 {
-    [HandlerEndpoint(HandlerMethod.Get, "/reports/{id}")]
+    [HandlerEndpoint(
+        HandlerMethod.Get,
+        "/reports/{id}",
+        ProducesContentTypes = ["application/pdf"])]
     public async Task<Result<FileResult>> HandleAsync(
         GetReport query, IReportService reports, CancellationToken ct)
     {
@@ -813,6 +816,8 @@ public class ReportHandler
     }
 }
 ```
+
+For file endpoints, `ProducesContentTypes` documents the file media types in OpenAPI. The runtime response content type still comes from the `Result.File(...)` value returned by the handler.
 
 ### OpenAPI Error Responses
 

--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -817,7 +817,7 @@ public class ReportHandler
 }
 ```
 
-For file endpoints, `ProducesContentTypes` documents the file media types in OpenAPI. The runtime response content type still comes from the `Result.File(...)` value returned by the handler.
+For file endpoints, `ProducesContentTypes` documents the file media types in OpenAPI. When omitted, the generated metadata defaults to `application/octet-stream`. Either way, the runtime response content type still comes from the `Result.File(...)` value returned by the handler.
 
 ### OpenAPI Error Responses
 

--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -234,6 +234,8 @@ All properties (including `Method` and `Route`) are also settable as named argum
 | `EndpointFilters` | `IEndpointFilter` types for this endpoint |
 | `SuccessStatusCodes` | Override auto-detected success status codes (200, 201, 202, 204, etc.) |
 | `ProducesStatusCodes` | Explicit error status codes for OpenAPI (e.g., `[404, 400]`) |
+| `AcceptsContentTypes` | Request body content types for generated `.Accepts<T>()` metadata |
+| `ProducesContentTypes` | Success response content types for generated `.Produces<T>()` metadata |
 | `Streaming` | `EndpointStreaming.ServerSentEvents` for SSE; `Default` for JSON array |
 | `SseEventType` | SSE `event:` field name for `addEventListener` |
 

--- a/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
@@ -145,6 +145,18 @@ public sealed class HandlerEndpointAttribute : Attribute
     public int[]? ProducesStatusCodes { get; set; }
 
     /// <summary>
+    /// Gets or sets the request content types accepted by the generated endpoint.
+    /// Used to generate <c>.Accepts&lt;T&gt;(...)</c> metadata when the message is bound from the request body.
+    /// </summary>
+    public string[]? AcceptsContentTypes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the response content types produced by generated success response metadata.
+    /// Used to add content type metadata to generated <c>.Produces&lt;T&gt;(...)</c> calls.
+    /// </summary>
+    public string[]? ProducesContentTypes { get; set; }
+
+    /// <summary>
     /// Gets or sets the streaming format for handlers that return <c>IAsyncEnumerable&lt;T&gt;</c>.
     /// When set to <see cref="EndpointStreaming.ServerSentEvents"/>, the generated endpoint wraps
     /// the result with <c>TypedResults.ServerSentEvents()</c> for real-time server-to-client push.

--- a/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
@@ -152,7 +152,8 @@ public sealed class HandlerEndpointAttribute : Attribute
 
     /// <summary>
     /// Gets or sets the response content types produced by generated success response metadata.
-    /// Used to add content type metadata to generated <c>.Produces&lt;T&gt;(...)</c> calls.
+    /// Used to add content type metadata to generated <c>.Produces&lt;T&gt;(...)</c> calls, or
+    /// <c>.Produces(...)</c> calls for file download endpoints.
     /// </summary>
     public string[]? ProducesContentTypes { get; set; }
 

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -710,6 +710,11 @@ internal static class EndpointGenerator
             source.AppendLine(".WithOpenApi()");
         }
 
+        if (endpoint.BindFromBody && endpoint.AcceptsContentTypes.Any())
+        {
+            source.AppendLine($".Accepts<{handler.MessageType.QualifiedName}>({FormatStringArguments(endpoint.AcceptsContentTypes)})");
+        }
+
         // Add Produces<T> metadata from return type
         if (endpoint.IsStreaming && endpoint.StreamingFormat == "ServerSentEvents")
         {
@@ -726,7 +731,7 @@ internal static class EndpointGenerator
             foreach (var statusCode in successStatusCodes)
             {
                 if (!string.IsNullOrEmpty(endpoint.ProducesType) && statusCode is not 202 and not 204)
-                    source.AppendLine($".Produces<{endpoint.ProducesType}>({statusCode})");
+                    source.AppendLine($".Produces<{endpoint.ProducesType}>({statusCode}{FormatContentTypeArguments(endpoint.ProducesContentTypes)})");
                 else
                     source.AppendLine($".Produces({statusCode})");
             }
@@ -1297,6 +1302,25 @@ internal static class EndpointGenerator
             .Replace("\"", "\\\"")
             .Replace("\r", "\\r")
             .Replace("\n", "\\n");
+    }
+
+    private static string FormatStringArguments(EquatableArray<string> values)
+    {
+        return string.Join(", ", values.Select(value => $"\"{EscapeString(value)}\""));
+    }
+
+    private static string FormatContentTypeArguments(EquatableArray<string> contentTypes)
+    {
+        var values = contentTypes.ToArray();
+        if (values.Length == 0)
+            return string.Empty;
+
+        var first = EscapeString(values[0]);
+        if (values.Length == 1)
+            return $", contentType: \"{first}\"";
+
+        var additional = string.Join(", ", values.Skip(1).Select(value => $"\"{EscapeString(value)}\""));
+        return $", contentType: \"{first}\", additionalContentTypes: new[] {{ {additional} }}";
     }
 
     /// <summary>

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -731,7 +731,12 @@ internal static class EndpointGenerator
             foreach (var statusCode in successStatusCodes)
             {
                 if (handler.ReturnType.IsFileResult && statusCode is not 202 and not 204)
-                    source.AppendLine($".Produces({statusCode}{FormatContentTypeArguments(endpoint.ProducesContentTypes)})");
+                {
+                    var fileContentTypes = endpoint.ProducesContentTypes.Any()
+                        ? endpoint.ProducesContentTypes
+                        : new EquatableArray<string>(["application/octet-stream"]);
+                    source.AppendLine($".Produces({statusCode}{FormatContentTypeArguments(fileContentTypes)})");
+                }
                 else if (!string.IsNullOrEmpty(endpoint.ProducesType) && statusCode is not 202 and not 204)
                     source.AppendLine($".Produces<{endpoint.ProducesType}>({statusCode}{FormatContentTypeArguments(endpoint.ProducesContentTypes)})");
                 else

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -715,7 +715,7 @@ internal static class EndpointGenerator
             source.AppendLine($".Accepts<{handler.MessageType.QualifiedName}>({FormatStringArguments(endpoint.AcceptsContentTypes)})");
         }
 
-        // Add Produces<T> metadata from return type
+        // Add response metadata from return type
         if (endpoint.IsStreaming && endpoint.StreamingFormat == "ServerSentEvents")
         {
             // SSE endpoints produce text/event-stream; TypedResults.ServerSentEvents()
@@ -730,7 +730,9 @@ internal static class EndpointGenerator
 
             foreach (var statusCode in successStatusCodes)
             {
-                if (!string.IsNullOrEmpty(endpoint.ProducesType) && statusCode is not 202 and not 204)
+                if (handler.ReturnType.IsFileResult && statusCode is not 202 and not 204)
+                    source.AppendLine($".Produces({statusCode}{FormatContentTypeArguments(endpoint.ProducesContentTypes)})");
+                else if (!string.IsNullOrEmpty(endpoint.ProducesType) && statusCode is not 202 and not 204)
                     source.AppendLine($".Produces<{endpoint.ProducesType}>({statusCode}{FormatContentTypeArguments(endpoint.ProducesContentTypes)})");
                 else
                     source.AppendLine($".Produces({statusCode})");

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -706,6 +706,12 @@ internal static class HandlerAnalyzer
         var explicitStatusCodes = GetIntArrayProperty(methodEndpointAttr, "ProducesStatusCodes") ??
                                   GetIntArrayProperty(classEndpointAttr, "ProducesStatusCodes");
 
+        var acceptsContentTypes = GetStringArrayProperty(methodEndpointAttr, "AcceptsContentTypes") ??
+                      GetStringArrayProperty(classEndpointAttr, "AcceptsContentTypes");
+
+        var producesContentTypes = GetStringArrayProperty(methodEndpointAttr, "ProducesContentTypes") ??
+                       GetStringArrayProperty(classEndpointAttr, "ProducesContentTypes");
+
         // Auto-detect Result factory method calls in the handler body (Created, Accepted, NotFound, Invalid, etc.)
         var detectedStatusCodes = DetectResultStatusCodes(handlerMethod, returnType, compilation, out var successStatusCodes);
 
@@ -803,6 +809,8 @@ internal static class HandlerAnalyzer
             GroupFilters = new(groupFilters),
             ProducesType = producesType,
             ProducesStatusCodes = new(producesStatusCodes),
+            AcceptsContentTypes = new(acceptsContentTypes ?? []),
+            ProducesContentTypes = new(producesContentTypes ?? []),
             SuccessStatusCodes = new(effectiveSuccessStatusCodes),
             IsStreaming = isStreaming,
             StreamingFormat = streamingFormat,

--- a/src/Foundatio.Mediator/Models/EndpointInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointInfo.cs
@@ -149,6 +149,16 @@ internal readonly record struct EndpointInfo
     public EquatableArray<int> ProducesStatusCodes { get; init; }
 
     /// <summary>
+    /// Request content types accepted by this endpoint when a request body is bound.
+    /// </summary>
+    public EquatableArray<string> AcceptsContentTypes { get; init; }
+
+    /// <summary>
+    /// Response content types used for generated success response metadata.
+    /// </summary>
+    public EquatableArray<string> ProducesContentTypes { get; init; }
+
+    /// <summary>
     /// When true, the group route prefix bypasses the global <c>EndpointRoutePrefix</c>.
     /// Set when the group <c>RoutePrefix</c> starts with <c>/</c> (e.g., <c>"/health"</c>).
     /// </summary>

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -806,6 +806,7 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
 
             public class ReportHandler
             {
+                [HandlerEndpoint(ProducesContentTypes = ["text/csv"])]
                 public Result<FileResult> Handle(ExportReport query)
                     => Result.File(new MemoryStream(), "text/csv", "report.csv");
             }
@@ -820,6 +821,8 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
         Assert.NotNull(endpointSource);
         // File results go through the result mapper which handles FileResult
         Assert.Contains("resultMapper.MapResult(result)", endpointSource);
+        Assert.Contains(".Produces(200, contentType: \"text/csv\")", endpointSource);
+        Assert.DoesNotContain(".Produces<global::Foundatio.Mediator.FileResult>", endpointSource);
     }
 
     [Fact]

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -826,6 +826,38 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
     }
 
     [Fact]
+    public void FileResultHandler_WithoutContentTypes_DefaultsToOctetStream()
+    {
+        var source = """
+            using System.IO;
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(
+                EndpointRoutePrefix = "api",
+                EndpointDiscovery = EndpointDiscovery.All
+            )]
+
+            public record ExportReport(int Id);
+
+            public class ReportHandler
+            {
+                public Result<FileResult> Handle(ExportReport query)
+                    => Result.File(new MemoryStream(), "application/pdf", "report.pdf");
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.Contains(".Produces(200, contentType: \"application/octet-stream\")", endpointSource);
+        Assert.DoesNotContain(".Produces<global::Foundatio.Mediator.FileResult>", endpointSource);
+    }
+
+    [Fact]
     public void TupleWithResultT_UsesInvokeAsyncAndToHttpResult()
     {
         var source = """

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -1303,6 +1303,81 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
     }
 
     [Fact]
+    public void ContentTypes_EmitsAcceptsAndProducesMetadata()
+    {
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record CreateOrder(string Name);
+            public record OrderView(string Id, string Name);
+
+            public class OrderHandler
+            {
+                [HandlerEndpoint(
+                    AcceptsContentTypes = ["application/json", "application/vnd.order+json"],
+                    ProducesContentTypes = ["application/json", "application/vnd.order+json"])]
+                public Result<OrderView> Handle(CreateOrder command) => new OrderView("1", command.Name);
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.Contains(".Accepts<", endpointSource);
+        Assert.Contains("(\"application/json\", \"application/vnd.order+json\")", endpointSource);
+        Assert.Contains(".Produces<", endpointSource);
+        Assert.Contains("(200, contentType: \"application/json\", additionalContentTypes: new[] { \"application/vnd.order+json\" })", endpointSource);
+    }
+
+    [Fact]
+    public void ContentTypes_MethodOverridesClassLevelDefaults()
+    {
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record CreateItem(string Name);
+            public record GetItem(string Id);
+            public record ItemView(string Id, string Name);
+
+            [HandlerEndpoint(
+                AcceptsContentTypes = ["application/json"],
+                ProducesContentTypes = ["application/json"])]
+            public class ItemHandler
+            {
+                [HandlerEndpoint(
+                    AcceptsContentTypes = ["application/vnd.item+json"],
+                    ProducesContentTypes = ["application/vnd.item+json"])]
+                public Result<ItemView> Handle(CreateItem command) => new ItemView("1", command.Name);
+
+                public Result<ItemView> Handle(GetItem query) => new ItemView(query.Id, "test");
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        var acceptsCount = endpointSource!.Split(".Accepts<").Length - 1;
+        Assert.Equal(1, acceptsCount);
+        Assert.Contains(".Accepts<", endpointSource);
+        Assert.Contains("(\"application/vnd.item+json\")", endpointSource);
+        Assert.Contains(".Produces<", endpointSource);
+        Assert.Contains("(200, contentType: \"application/vnd.item+json\")", endpointSource);
+        Assert.Contains("(200, contentType: \"application/json\")", endpointSource);
+    }
+
+    [Fact]
     public void NoProducesStatusCodes_NoProducesProblemEmitted()
     {
         var source = """


### PR DESCRIPTION
Adds content-type metadata overrides for generated endpoints so migrations can preserve request and response media type declarations.

Summary:
- Add `AcceptsContentTypes` and `ProducesContentTypes` to `HandlerEndpointAttribute`.
- Carry content-type metadata through endpoint analysis and generated Minimal API metadata.
- Emit `.Accepts<T>()` for body-bound endpoints.
- Emit content-type arguments for generated success response metadata, using `.Produces<T>()` for typed responses and `.Produces()` for `Result<FileResult>` file downloads.
- Cover class defaults, method overrides, multiple content types, and file response content types in endpoint generation tests.
- Document the new endpoint properties and the file download use case.

Validation:
- `dotnet build Foundatio.Mediator.slnx`
- `dotnet test Foundatio.Mediator.slnx`