### PR TITLE
Bind IFormFile / form messages from multipart form data (antiforgery opt-in)

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -227,6 +227,13 @@ The following properties on `MediatorConfigurationAttribute` control endpoint ge
   - `Exact`: Uses the message type name as-is (e.g., `"GetProduct"`)
   - `Spaced`: Splits PascalCase into space-separated words (e.g., `"Get Product"`)
 
+**`EndpointDisableAntiforgery`** (`bool`)
+
+- **Default:** `false` — ASP.NET Core's secure default (antiforgery required on form endpoints) is preserved
+- **Effect:** The assembly-wide default for disabling antiforgery (CSRF) validation on `multipart/form-data` (`IFormFile`) endpoints
+- **Use Case:** APIs whose form endpoints aren't browser-reachable or use non-cookie auth (bearer tokens, API keys)
+- **Override:** `[HandlerEndpoint(DisableAntiforgery = ...)]` on a handler method or class. Do **not** disable for browser-reachable, cookie-authenticated endpoints — see [File Uploads](./endpoints.md#file-uploads)
+
 ### Example Configuration
 
 All configuration is done via the assembly attribute in any `.cs` file in your project:

--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -236,6 +236,7 @@ All properties (including `Method` and `Route`) are also settable as named argum
 | `ProducesStatusCodes` | Explicit error status codes for OpenAPI (e.g., `[404, 400]`) |
 | `AcceptsContentTypes` | Request body content types for generated `.Accepts<T>()` metadata |
 | `ProducesContentTypes` | Success response content types for generated `.Produces<T>()` metadata, or `.Produces()` metadata for file downloads |
+| `DisableAntiforgery` | `true` to skip antiforgery (CSRF) validation on a form (`multipart/form-data`) endpoint. Default: required. Only for non-browser / non-cookie-auth endpoints — see [File Uploads](#file-uploads) |
 | `Streaming` | `EndpointStreaming.ServerSentEvents` for SSE; `Default` for JSON array |
 | `SseEventType` | SSE `event:` field name for `addEventListener` |
 
@@ -517,6 +518,14 @@ public record GetProduct(string ProductId);
 // → GET /api/products/{productId}
 ```
 
+With an **explicit route template**, any property whose name matches a `{placeholder}` segment binds from the route — even when it isn't named `Id`, and for any HTTP method. Inline constraints (`{number:int}`) are matched too:
+
+```csharp
+[HandlerEndpoint(HandlerMethod.Get, "contracts/{contractNumber}")]
+public Result<Contract> Handle(GetContract query);   // record GetContract(string ContractNumber)
+// → contractNumber binds from the path, not the query string
+```
+
 ### Query Parameters
 
 For GET/DELETE requests, non-ID properties become query parameters:
@@ -601,6 +610,37 @@ public record UpdateProduct(string ProductId, string? Name, decimal? Price);
 // → MapPut("/{productId}", async (string productId, [FromBody] UpdateProduct message, ...) =>
 //   { var mergedMessage = message with { ProductId = productId }; ... })
 ```
+
+### File Uploads
+
+When a POST/PUT/PATCH message exposes an `IFormFile`, `IFormFileCollection`, or `IFormCollection` property, the whole message binds from `multipart/form-data` instead of the JSON body. File properties bind by name (no attribute — how Minimal APIs bind `IFormFile`), any other fields bind with `[FromForm]`, and route placeholders still bind from the route:
+
+```csharp
+public sealed record UploadFile(string ContractNumber, IFormFile File);
+
+[HandlerEndpoint(HandlerMethod.Post, "upload/{contractNumber}")]
+public Task<Result<string>> HandleAsync(UploadFile cmd) { ... }
+// → MapPost("upload/{contractNumber}", (string contractNumber, IFormFile file, ...) =>
+//   { var message = new UploadFile(ContractNumber: contractNumber, File: file); ... })
+```
+
+The form-field name matches the parameter name (`File` → `file`). `[FromBody]` and form binding are mutually exclusive — a message with a file property is never bound from a JSON body.
+
+::: warning Antiforgery
+ASP.NET Core requires [antiforgery (CSRF) validation](https://learn.microsoft.com/aspnet/core/security/anti-request-forgery#antiforgery-with-minimal-apis) on form endpoints by default, and the generator **preserves that default** — it does not call `.DisableAntiforgery()` on its own. If your app runs the antiforgery middleware, a form POST without a valid token is rejected before the handler runs.
+
+Disable it **only** for endpoints that aren't vulnerable to CSRF — not callable from a browser, or secured with non-cookie auth (bearer tokens, API keys). Disabling is explicit, resolved method → class → assembly:
+
+```csharp
+// Per endpoint or handler class:
+[HandlerEndpoint(HandlerMethod.Post, "upload", DisableAntiforgery = true)]
+
+// Assembly-wide default (e.g. an API that's entirely token/API-key authenticated):
+[assembly: MediatorConfiguration(EndpointDisableAntiforgery = true)]
+```
+
+A handler-level `DisableAntiforgery = false` overrides an assembly default of `true`, so you can opt out globally and still re-protect a specific browser-facing endpoint.
+:::
 
 ### Binding Attributes on Message Properties
 
@@ -944,13 +984,14 @@ app.MapMediatorEndpoints(c =>
 ```csharp
 [assembly: MediatorConfiguration(
     EndpointDiscovery = EndpointDiscovery.All,
-    EndpointRoutePrefix = "api",          // Global route prefix (default: "api")
-    AuthorizationRequired = false,         // Require auth for all endpoints
-    EndpointFilters = [typeof(MyFilter)]  // Global endpoint filters
+    EndpointRoutePrefix = "api",            // Global route prefix (default: "api")
+    AuthorizationRequired = false,          // Require auth for all endpoints
+    EndpointFilters = [typeof(MyFilter)],   // Global endpoint filters
+    EndpointDisableAntiforgery = false      // Default for form endpoints (default: false — antiforgery required)
 )]
 ```
 
-Set `EndpointRoutePrefix = ""` to disable the global prefix entirely.
+Set `EndpointRoutePrefix = ""` to disable the global prefix entirely. See [File Uploads](#file-uploads) for `EndpointDisableAntiforgery`.
 
 ## Endpoint Conventions
 

--- a/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
@@ -158,6 +158,22 @@ public sealed class HandlerEndpointAttribute : Attribute
     public string[]? ProducesContentTypes { get; set; }
 
     /// <summary>
+    /// Gets or sets whether to disable antiforgery (CSRF) token validation for a form-bound endpoint.
+    /// Has no effect on endpoints that don't bind from <c>multipart/form-data</c>.
+    /// <para>
+    /// ASP.NET Core requires antiforgery validation for form endpoints by default. The generator
+    /// preserves that secure default and only emits <c>.DisableAntiforgery()</c> when this is set
+    /// to <c>true</c> (or the assembly-level <c>EndpointDisableAntiforgery</c> default is enabled).
+    /// </para>
+    /// <para>
+    /// Only disable for endpoints that aren't vulnerable to CSRF — e.g. not callable from a browser,
+    /// or secured with non-cookie authentication (bearer tokens, API keys). Do <b>not</b> disable for
+    /// browser-reachable, cookie-authenticated endpoints.
+    /// </para>
+    /// </summary>
+    public bool DisableAntiforgery { get; set; }
+
+    /// <summary>
     /// Gets or sets the streaming format for handlers that return <c>IAsyncEnumerable&lt;T&gt;</c>.
     /// When set to <see cref="EndpointStreaming.ServerSentEvents"/>, the generated endpoint wraps
     /// the result with <c>TypedResults.ServerSentEvents()</c> for real-time server-to-client push.

--- a/src/Foundatio.Mediator.Abstractions/MediatorConfigurationAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/MediatorConfigurationAttribute.cs
@@ -143,4 +143,16 @@ public sealed class MediatorConfigurationAttribute : Attribute
     /// Default: <see cref="EndpointSummaryStyle.Exact"/>.
     /// </summary>
     public EndpointSummaryStyle EndpointSummaryStyle { get; set; }
+
+    /// <summary>
+    /// The default for disabling antiforgery (CSRF) token validation on form-bound endpoints.
+    /// When <c>true</c>, generated <c>multipart/form-data</c> endpoints emit <c>.DisableAntiforgery()</c>
+    /// unless a handler opts back in via <c>[HandlerEndpoint(DisableAntiforgery = false)]</c>.
+    /// Default: <c>false</c> — ASP.NET Core's secure default (antiforgery required) is preserved.
+    /// <para>
+    /// Enable only for assemblies whose form endpoints aren't vulnerable to CSRF — e.g. APIs that
+    /// aren't browser-reachable or use non-cookie authentication (bearer tokens, API keys).
+    /// </para>
+    /// </summary>
+    public bool EndpointDisableAntiforgery { get; set; }
 }

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -667,10 +667,12 @@ internal static class EndpointGenerator
             source.AppendLine($".WithDescription(\"{escapedDescription}\")");
         }
 
-        // Form endpoints keep ASP.NET Core's secure default (antiforgery required). Emit
-        // .DisableAntiforgery() only when the handler opts out, or the assembly default does.
-        // Disabling drops CSRF protection, so it is never the implicit choice.
-        if (endpoint.BindFromForm && (endpoint.DisableAntiforgery ?? defaultDisableAntiforgery))
+        // An explicit [HandlerEndpoint(DisableAntiforgery = ...)] is always honored — it's a harmless
+        // no-op on non-form endpoints, and honoring it avoids a silently-ignored setting. The
+        // assembly-wide default only applies to form endpoints (where antiforgery is meaningful), so
+        // it never splatters .DisableAntiforgery() across every GET/JSON endpoint. Form endpoints
+        // otherwise keep ASP.NET Core's secure default (antiforgery required).
+        if (endpoint.DisableAntiforgery ?? (endpoint.BindFromForm && defaultDisableAntiforgery))
         {
             source.AppendLine(".DisableAntiforgery()");
         }

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -437,7 +437,7 @@ internal static class EndpointGenerator
                     ? "endpoints"
                     : groupVarName;
 
-                GenerateEndpoint(source, handler, targetGroup, hasAsParametersAttribute, hasFromBodyAttribute, hasWithOpenApi, groupRequireAuth || endpointDefaults.RequireAuth, assemblySuffix, endpointDefaults.SummaryStyle, endpointDefaults.Conventions, routeOverride);
+                GenerateEndpoint(source, handler, targetGroup, hasAsParametersAttribute, hasFromBodyAttribute, hasWithOpenApi, groupRequireAuth || endpointDefaults.RequireAuth, assemblySuffix, endpointDefaults.SummaryStyle, endpointDefaults.Conventions, endpointDefaults.DisableAntiforgery, routeOverride);
 
                 // Collect endpoint info for logging
                 var endpointRoute = routeOverride ?? handler.Endpoint!.Value.Route;
@@ -610,6 +610,7 @@ internal static class EndpointGenerator
         string assemblySuffix,
         string summaryStyle,
         EquatableArray<EndpointConventionInfo> assemblyConventions,
+        bool defaultDisableAntiforgery,
         string? routeOverride = null)
     {
         var endpoint = handler.Endpoint!.Value;
@@ -664,6 +665,14 @@ internal static class EndpointGenerator
         {
             var escapedDescription = EscapeString(descriptionText!);
             source.AppendLine($".WithDescription(\"{escapedDescription}\")");
+        }
+
+        // Form endpoints keep ASP.NET Core's secure default (antiforgery required). Emit
+        // .DisableAntiforgery() only when the handler opts out, or the assembly default does.
+        // Disabling drops CSRF protection, so it is never the implicit choice.
+        if (endpoint.BindFromForm && (endpoint.DisableAntiforgery ?? defaultDisableAntiforgery))
+        {
+            source.AppendLine(".DisableAntiforgery()");
         }
 
         // Add AllowAnonymous if handler opts out of group-level auth
@@ -849,7 +858,52 @@ internal static class EndpointGenerator
         var isAsync = handler.IsAsync;
         var asyncKeyword = isAsync ? "async " : "";
 
-        if (endpoint.BindFromBody)
+        if (endpoint.BindFromForm)
+        {
+            // multipart/form-data: route params bind by name, file params (IFormFile/...) bind by name
+            // with no attribute, other fields carry [FromForm]. Everything merges into the message.
+            var routeParams = endpoint.RouteParameters;
+            var formParams = endpoint.FormParameters;
+            var allParams = routeParams.Concat(formParams).ToList();
+
+            source.Append($"{asyncKeyword}(");
+
+            foreach (var param in routeParams)
+                source.Append($"{param.Type.FullName} {param.Name}, ");
+
+            foreach (var param in formParams)
+            {
+                if (param.BindingAttributeSyntax != null)
+                    source.Append($"{param.BindingAttributeSyntax} ");
+                source.Append($"{param.Type.FullName} {param.Name}, ");
+            }
+
+            source.Append("Microsoft.AspNetCore.Http.HttpContext httpContext, Foundatio.Mediator.IMediator mediator, System.Threading.CancellationToken cancellationToken) =>");
+            source.AppendLine();
+            source.AppendLine("{");
+            source.IncrementIndent();
+
+            source.AppendLine("using var callContext = Foundatio.Mediator.CallContext.Rent().Set(httpContext).Set(httpContext.Request).Set(httpContext.Response).Set(httpContext.User);");
+
+            if (handler.MessageType.IsRecord)
+            {
+                source.Append($"var message = new {messageType}(");
+                source.Append(string.Join(", ", allParams.Select(p => $"{p.PropertyName}: {p.Name}")));
+                source.AppendLine(");");
+            }
+            else
+            {
+                source.Append($"var message = new {messageType} {{ ");
+                source.Append(string.Join(", ", allParams.Select(p => $"{p.PropertyName} = {p.Name}")));
+                source.AppendLine(" };");
+            }
+
+            GenerateHandlerCall(source, handler, wrapperClassName, "message", isAsync, assemblySuffix);
+
+            source.DecrementIndent();
+            source.Append("}");
+        }
+        else if (endpoint.BindFromBody)
         {
             var routeParams = endpoint.RouteParameters;
             var bindingParams = endpoint.BindingParameters;

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -639,7 +639,7 @@ internal static class HandlerAnalyzer
         };
 
         // Analyze message type for parameters (before route computation, since route params go into the shared input)
-        var (routeParams, queryParams, bindingParams, supportsAsParameters, hasParameterlessConstructor) = AnalyzeMessageParameters(messageType, httpMethod, compilation, isActionVerb: actionVerb != null, explicitRoute: explicitRoute);
+        var (routeParams, queryParams, bindingParams, formParams, bindFromForm, supportsAsParameters, hasParameterlessConstructor) = AnalyzeMessageParameters(messageType, httpMethod, compilation, isActionVerb: actionVerb != null, explicitRoute: explicitRoute);
 
         // ── Shared route computation ───────────────────────────────
         // Uses the same code path as MediatorInfoAnalyzer (FMED017 diagnostic).
@@ -712,6 +712,11 @@ internal static class HandlerAnalyzer
         var producesContentTypes = GetStringArrayProperty(methodEndpointAttr, "ProducesContentTypes") ??
                        GetStringArrayProperty(classEndpointAttr, "ProducesContentTypes");
 
+        // Handler-level antiforgery override (method -> class). Null when unset; the generator then
+        // falls back to the assembly-level EndpointDisableAntiforgery default.
+        var disableAntiforgery = GetBoolProperty(methodEndpointAttr, "DisableAntiforgery") ??
+                                 GetBoolProperty(classEndpointAttr, "DisableAntiforgery");
+
         // Auto-detect Result factory method calls in the handler body (Created, Accepted, NotFound, Invalid, etc.)
         var detectedStatusCodes = DetectResultStatusCodes(handlerMethod, returnType, compilation, out var successStatusCodes);
 
@@ -727,8 +732,9 @@ internal static class HandlerAnalyzer
         // Extract ProducesType from return type for auto Produces<T>() generation
         string? producesType = ExtractProducesType(returnType, compilation);
 
-        // Determine binding strategy
-        bool bindFromBody = httpMethod is "POST" or "PUT" or "PATCH";
+        // Determine binding strategy. Form-bound messages (multipart upload) bind from the form,
+        // not from a JSON body, so the two are mutually exclusive.
+        bool bindFromBody = (httpMethod is "POST" or "PUT" or "PATCH") && !bindFromForm;
 
         // For auto-generated action verb routes, check if all properties are already
         // covered by route params (IDs). If so, skip body binding.
@@ -796,7 +802,10 @@ internal static class HandlerAnalyzer
             RouteParameters = new(routeParams),
             QueryParameters = new(queryParams),
             BindingParameters = new(bindingParams),
+            FormParameters = new(formParams),
             BindFromBody = bindFromBody,
+            BindFromForm = bindFromForm,
+            DisableAntiforgery = disableAntiforgery,
             SupportsAsParameters = supportsAsParameters,
             HasParameterlessConstructor = hasParameterlessConstructor,
             GenerateEndpoint = true,
@@ -969,12 +978,13 @@ internal static class HandlerAnalyzer
     /// <summary>
     /// Analyzes message type properties to determine route and query parameters.
     /// </summary>
-    private static (EndpointParameterInfo[] routeParams, EndpointParameterInfo[] queryParams, EndpointParameterInfo[] bindingParams, bool supportsAsParameters, bool hasParameterlessConstructor)
+    private static (EndpointParameterInfo[] routeParams, EndpointParameterInfo[] queryParams, EndpointParameterInfo[] bindingParams, EndpointParameterInfo[] formParams, bool bindFromForm, bool supportsAsParameters, bool hasParameterlessConstructor)
         AnalyzeMessageParameters(INamedTypeSymbol messageType, string httpMethod, Compilation compilation, bool isActionVerb = false, string? explicitRoute = null)
     {
         var routeParams = new List<EndpointParameterInfo>();
         var queryParams = new List<EndpointParameterInfo>();
         var bindingParams = new List<EndpointParameterInfo>();
+        var formParams = new List<EndpointParameterInfo>();
 
         // Placeholder names declared in an explicit [HandlerEndpoint] route template (case-insensitive).
         var routePlaceholders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -998,6 +1008,13 @@ internal static class HandlerAnalyzer
             .OfType<IPropertySymbol>()
             .Where(p => p.DeclaredAccessibility == Accessibility.Public && p.GetMethod != null)
             .ToList();
+
+        // A body-bound (POST/PUT/PATCH) message that exposes an IFormFile/IFormFileCollection/IFormCollection
+        // property binds from multipart/form-data rather than from a JSON body: files bind by name and other
+        // fields use [FromForm]. Without this the whole message gets [FromBody] and multipart requests fail
+        // (415, and IFormFile cannot be deserialized from JSON anyway).
+        bool bindFromForm = httpMethod is "POST" or "PUT" or "PATCH"
+            && properties.Any(p => IsFormParameterType(p.Type));
 
         foreach (var prop in properties)
         {
@@ -1033,6 +1050,15 @@ internal static class HandlerAnalyzer
                 continue;
             }
 
+            // In form mode every remaining property is bound from the form: file types by name (no
+            // attribute) and other fields via [FromForm].
+            if (bindFromForm)
+            {
+                var formAttr = IsFormParameterType(prop.Type) ? null : "[Microsoft.AspNetCore.Mvc.FromForm]";
+                formParams.Add(paramInfo with { IsFormParameter = true, BindingAttributeSyntax = formAttr });
+                continue;
+            }
+
             // Determine if this should be a route parameter
             bool isIdProperty = prop.Name.Equals("Id", StringComparison.OrdinalIgnoreCase) ||
                                 prop.Name.EndsWith("Id", StringComparison.OrdinalIgnoreCase);
@@ -1051,7 +1077,19 @@ internal static class HandlerAnalyzer
             }
         }
 
-        return (routeParams.ToArray(), queryParams.ToArray(), bindingParams.ToArray(), supportsAsParameters, hasParameterlessConstructor || isRecordWithDefaults);
+        return (routeParams.ToArray(), queryParams.ToArray(), bindingParams.ToArray(), formParams.ToArray(), bindFromForm, supportsAsParameters, hasParameterlessConstructor || isRecordWithDefaults);
+    }
+
+    /// <summary>
+    /// Whether the type is an ASP.NET Core form file type bound directly from multipart/form-data:
+    /// <c>IFormFile</c>, <c>IFormFileCollection</c>, or <c>IFormCollection</c>.
+    /// </summary>
+    private static bool IsFormParameterType(ITypeSymbol type)
+    {
+        return type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) is
+            "global::Microsoft.AspNetCore.Http.IFormFile" or
+            "global::Microsoft.AspNetCore.Http.IFormFileCollection" or
+            "global::Microsoft.AspNetCore.Http.IFormCollection";
     }
 
     /// <summary>

--- a/src/Foundatio.Mediator/MediatorGenerator.cs
+++ b/src/Foundatio.Mediator/MediatorGenerator.cs
@@ -116,6 +116,7 @@ public sealed class MediatorGenerator : IIncrementalGenerator
         var policies = Array.Empty<string>();
         var roles = Array.Empty<string>();
         string summaryStyle = "Exact";
+        bool disableAntiforgery = false;
         bool endpointConfigured = false;
 
         if (configAttr != null)
@@ -189,6 +190,9 @@ public sealed class MediatorGenerator : IIncrementalGenerator
                     case "EndpointSummaryStyle" when arg.Value.Value is int v:
                         summaryStyle = v switch { 1 => "Spaced", _ => "Exact" };
                         break;
+                    case "EndpointDisableAntiforgery" when arg.Value.Value is bool b:
+                        disableAntiforgery = b;
+                        break;
                 }
             }
         }
@@ -229,6 +233,7 @@ public sealed class MediatorGenerator : IIncrementalGenerator
             Policies = new(policies),
             Roles = new(roles),
             SummaryStyle = summaryStyle,
+            DisableAntiforgery = disableAntiforgery,
             Conventions = new(assemblyConventions),
             IsConfigured = endpointConfigured
         };

--- a/src/Foundatio.Mediator/Models/EndpointDefaultsInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointDefaultsInfo.cs
@@ -47,6 +47,13 @@ internal readonly record struct EndpointDefaultsInfo
     public string SummaryStyle { get; init; }
 
     /// <summary>
+    /// The assembly-level default for disabling antiforgery validation on form-bound endpoints.
+    /// Populated from <c>EndpointDisableAntiforgery</c> on <c>[assembly: MediatorConfiguration]</c>.
+    /// A handler-level <c>[HandlerEndpoint(DisableAntiforgery = ...)]</c> overrides this.
+    /// </summary>
+    public bool DisableAntiforgery { get; init; }
+
+    /// <summary>
     /// Assembly-level endpoint conventions (global defaults).
     /// These apply to all endpoints unless overridden by class or method level conventions.
     /// </summary>
@@ -66,6 +73,7 @@ internal readonly record struct EndpointDefaultsInfo
         Policies = EquatableArray<string>.Empty,
         Roles = EquatableArray<string>.Empty,
         SummaryStyle = "Exact",
+        DisableAntiforgery = false,
         Conventions = EquatableArray<EndpointConventionInfo>.Empty,
         IsConfigured = false
     };

--- a/src/Foundatio.Mediator/Models/EndpointInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointInfo.cs
@@ -74,6 +74,26 @@ internal readonly record struct EndpointInfo
     public bool BindFromBody { get; init; }
 
     /// <summary>
+    /// Whether the message should be bound from a multipart/form-data request.
+    /// Set when a POST/PUT/PATCH message exposes an <c>IFormFile</c>/<c>IFormFileCollection</c>/<c>IFormCollection</c>
+    /// property. Mutually exclusive with <see cref="BindFromBody"/>; the endpoint also emits <c>.DisableAntiforgery()</c>.
+    /// </summary>
+    public bool BindFromForm { get; init; }
+
+    /// <summary>
+    /// Form parameters (files bound by name with no attribute; other fields with <c>[FromForm]</c>)
+    /// merged into the message when <see cref="BindFromForm"/> is true.
+    /// </summary>
+    public EquatableArray<EndpointParameterInfo> FormParameters { get; init; }
+
+    /// <summary>
+    /// Handler-level override (method then class) for disabling antiforgery validation on a form endpoint.
+    /// <c>null</c> when unset — the generator then falls back to the assembly-level default. Only meaningful
+    /// when <see cref="BindFromForm"/> is true.
+    /// </summary>
+    public bool? DisableAntiforgery { get; init; }
+
+    /// <summary>
     /// Whether the message type supports [AsParameters] binding.
     /// True when message has a parameterless constructor with settable properties.
     /// </summary>
@@ -233,6 +253,13 @@ internal readonly record struct EndpointParameterInfo
     /// Whether this is a route parameter (vs query parameter).
     /// </summary>
     public bool IsRouteParameter { get; init; }
+
+    /// <summary>
+    /// Whether this parameter is bound from a multipart/form-data request.
+    /// File parameters (<c>IFormFile</c>/<c>IFormFileCollection</c>/<c>IFormCollection</c>) bind by name
+    /// with no attribute; other form fields carry a <c>[FromForm]</c> <see cref="BindingAttributeSyntax"/>.
+    /// </summary>
+    public bool IsFormParameter { get; init; }
 
     /// <summary>
     /// The full attribute syntax to emit on the endpoint lambda parameter

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -3038,5 +3038,200 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
         Assert.DoesNotContain("[Microsoft.AspNetCore.Mvc.FromQuery]", endpointSource);
         Assert.Contains("Number: number", endpointSource);
     }
+
+    [Fact]
+    public void FormUpload_WithRouteParam_BindsFileFromFormAndIdFromRoute()
+    {
+        // Repro for https://github.com/FoundatioFx/Foundatio.Mediator/issues/205 (POST + IFormFile):
+        // a message exposing IFormFile must bind from multipart/form-data, not [FromBody], and the
+        // {contractNumber} route segment must still bind from the route. (GenerateEndpointSource also
+        // asserts the generated code compiles against the ASP.NET Core references.)
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public sealed record UploadFile(string ContractNumber, IFormFile File);
+
+            [HandlerEndpointGroup(Name = "Hobex", RoutePrefix = "Hobex")]
+            public class HobexHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "Upload/{contractNumber}")]
+                public string Handle(UploadFile cmd) => cmd.ContractNumber;
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.Contains("MapPost(\"Upload/{contractNumber}\"", endpointSource);
+        // No JSON body binding; the file binds from the form and the id from the route.
+        Assert.DoesNotContain("[Microsoft.AspNetCore.Mvc.FromBody]", endpointSource);
+        Assert.Contains("IFormFile file", endpointSource);
+        Assert.Contains("ContractNumber: contractNumber", endpointSource);
+        Assert.Contains("File: file", endpointSource);
+        // Antiforgery stays required by default (ASP.NET Core's secure default is preserved).
+        Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
+    }
+
+    [Fact]
+    public void FormUpload_WithScalarMetadata_UsesFromFormForNonFileFields()
+    {
+        // A non-file field alongside the upload binds via [FromForm]; the file itself takes no attribute.
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public sealed record UploadDoc(IFormFile File, string Description);
+
+            public class UploadHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "docs")]
+                public string Handle(UploadDoc cmd) => cmd.Description;
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.Contains("MapPost(\"docs\"", endpointSource);
+        Assert.Contains("IFormFile file", endpointSource);
+        Assert.Contains("[Microsoft.AspNetCore.Mvc.FromForm] string description", endpointSource);
+        Assert.DoesNotContain("[Microsoft.AspNetCore.Mvc.FromBody]", endpointSource);
+        Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
+    }
+
+    [Fact]
+    public void FormUpload_FileCollection_BindsFromForm()
+    {
+        // IFormFileCollection is also recognized as a form-bound parameter.
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public sealed record UploadMany(IFormFileCollection Files);
+
+            public class BatchHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "batch")]
+                public string Handle(UploadMany cmd) => cmd.Files.Count.ToString();
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.Contains("IFormFileCollection files", endpointSource);
+        Assert.DoesNotContain("[Microsoft.AspNetCore.Mvc.FromBody]", endpointSource);
+        Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
+    }
+
+    [Fact]
+    public void FormUpload_DisableAntiforgeryAttribute_EmitsDisableAntiforgery()
+    {
+        // Opt-in per handler: [HandlerEndpoint(DisableAntiforgery = true)] emits .DisableAntiforgery().
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public sealed record UploadFile(string ContractNumber, IFormFile File);
+
+            [HandlerEndpointGroup(Name = "Hobex", RoutePrefix = "Hobex")]
+            public class HobexHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "Upload/{contractNumber}", DisableAntiforgery = true)]
+                public string Handle(UploadFile cmd) => cmd.ContractNumber;
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.Contains("IFormFile file", endpointSource);
+        Assert.Contains(".DisableAntiforgery()", endpointSource);
+    }
+
+    [Fact]
+    public void FormUpload_AssemblyDisableAntiforgeryDefault_EmitsDisableAntiforgery()
+    {
+        // Opt-in for the whole assembly via MediatorConfiguration(EndpointDisableAntiforgery = true).
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All, EndpointDisableAntiforgery = true)]
+
+            public sealed record UploadMany(IFormFileCollection Files);
+
+            public class BatchHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "batch")]
+                public string Handle(UploadMany cmd) => cmd.Files.Count.ToString();
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.Contains(".DisableAntiforgery()", endpointSource);
+    }
+
+    [Fact]
+    public void FormUpload_HandlerOptOutOverridesAssemblyDefault()
+    {
+        // Handler-level DisableAntiforgery = false wins over an assembly default of true.
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All, EndpointDisableAntiforgery = true)]
+
+            public sealed record UploadMany(IFormFileCollection Files);
+
+            public class BatchHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "batch", DisableAntiforgery = false)]
+                public string Handle(UploadMany cmd) => cmd.Files.Count.ToString();
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
+    }
+
+    [Fact]
+    public void NonFormPost_StillBindsFromBody()
+    {
+        // Regression guard: a POST without any form-file property keeps JSON body binding.
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public sealed record CreateWidget(string Name, int Quantity);
+
+            public class WidgetHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "widgets")]
+                public string Handle(CreateWidget cmd) => cmd.Name;
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.Contains("MapPost(\"widgets\"", endpointSource);
+        Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
+        Assert.DoesNotContain("[Microsoft.AspNetCore.Mvc.FromForm]", endpointSource);
+    }
 }
 

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -3233,5 +3233,59 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
         Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
         Assert.DoesNotContain("[Microsoft.AspNetCore.Mvc.FromForm]", endpointSource);
     }
+
+    [Fact]
+    public void DisableAntiforgeryAttribute_OnNonFormEndpoint_IsHonored()
+    {
+        // An explicit [HandlerEndpoint(DisableAntiforgery = true)] is honored even on a JSON endpoint
+        // (a harmless no-op), rather than being silently dropped.
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public sealed record CreateWidget(string Name, int Quantity);
+
+            public class WidgetHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "widgets", DisableAntiforgery = true)]
+                public string Handle(CreateWidget cmd) => cmd.Name;
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.Contains("MapPost(\"widgets\"", endpointSource);
+        Assert.Contains(".DisableAntiforgery()", endpointSource);
+    }
+
+    [Fact]
+    public void AssemblyDisableAntiforgeryDefault_DoesNotApplyToNonFormEndpoints()
+    {
+        // The assembly-wide default only targets form endpoints — it must not splatter
+        // .DisableAntiforgery() across ordinary GET/JSON endpoints.
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All, EndpointDisableAntiforgery = true)]
+
+            public sealed record CreateWidget(string Name, int Quantity);
+            public record GetWidget(string Id);
+
+            public class WidgetHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "widgets")]
+                public string Handle(CreateWidget cmd) => cmd.Name;
+
+                public string Handle(GetWidget query) => query.Id;
+            }
+            """;
+
+        var endpointSource = GenerateEndpointSource(source);
+        if (endpointSource is null) return;
+
+        Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
+    }
 }
 

--- a/tests/Foundatio.Mediator.Tests/GeneratorTestBase.cs
+++ b/tests/Foundatio.Mediator.Tests/GeneratorTestBase.cs
@@ -261,6 +261,7 @@ public abstract class GeneratorTestBase(ITestOutputHelper output) : TestWithLogg
             "Microsoft.AspNetCore.Http.Abstractions.dll",
             "Microsoft.AspNetCore.Http.dll",
             "Microsoft.AspNetCore.Http.Extensions.dll",
+            "Microsoft.AspNetCore.Http.Features.dll",
             "Microsoft.AspNetCore.Http.Results.dll",
             "Microsoft.AspNetCore.Metadata.dll",
             "Microsoft.AspNetCore.Routing.dll",


### PR DESCRIPTION
## Problem

Fixes the POST + `IFormFile` / multipart case of #205. (The GET `[FromQuery]` half was #232, now merged.)

A POST/PUT/PATCH handler whose message exposes an `IFormFile` (or `IFormFileCollection`/`IFormCollection`) was bound with `[FromBody]` for the whole message:

```csharp
public sealed record UploadFile(string ContractNumber, IFormFile File);

[HandlerEndpoint(HandlerMethod.Post, "Upload/{contractNumber}")]
public Task<Result<string>> HandleAsync(UploadFile cmd, CancellationToken ct) => ...;
```

generated `[Microsoft.AspNetCore.Mvc.FromBody] UploadFile message`. The JSON body binder refuses `multipart/form-data` → **415**, and `IFormFile` can't be deserialized from a JSON body anyway — so file-upload endpoints were unusable.

## Fix

A POST/PUT/PATCH message that exposes a form-file property now binds from the form instead of the body:

- File properties (`IFormFile`/`IFormFileCollection`/`IFormCollection`) bind by name with **no attribute** (how Minimal APIs bind `IFormFile`).
- Other fields bind via `[FromForm]`.
- Route placeholders still bind from the route (from #232).
- All parameters are merged into the message.

`BindFromForm` and `BindFromBody` are mutually exclusive; non-form POST/PUT/PATCH messages are unchanged.

Generated output for the repro:

```csharp
hobexGroup.MapPost("Upload/{contractNumber}",
    (string contractNumber, Microsoft.AspNetCore.Http.IFormFile file,
     HttpContext httpContext, IMediator mediator, CancellationToken cancellationToken) =>
{
    var message = new UploadFile(ContractNumber: contractNumber, File: file);
    ...
});
```

## Antiforgery: secure by default, opt-in to disable

ASP.NET Core requires antiforgery (CSRF) validation for form endpoints by default. **The generator preserves that** — it does **not** emit `.DisableAntiforgery()` on its own. The library can't know how a consumer authenticates, and silently disabling would strip CSRF protection from cookie-authenticated, browser-reachable endpoints.

Disabling is **opt-in and explicit**, resolved method → class → assembly:

```csharp
// per endpoint / handler class
[HandlerEndpoint(HandlerMethod.Post, "upload", DisableAntiforgery = true)]

// assembly-wide default (e.g. an API that's entirely bearer/API-key authenticated)
[assembly: MediatorConfiguration(EndpointDisableAntiforgery = true)]
```

This follows the [framework's own guidance](https://learn.microsoft.com/aspnet/core/security/anti-request-forgery#antiforgery-with-minimal-apis): only disable for endpoints not vulnerable to CSRF (not browser-callable, or non-cookie auth). The trade-off lives visibly in the consumer's code, where it belongs. Consumers with form endpoints and no antiforgery setup get ASP.NET Core's standard fail-fast — identical to hand-written minimal-API code — pointing them at the fix.

## Tests

Added to `EndpointGenerationTests`:
- `FormUpload_WithRouteParam_BindsFileFromFormAndIdFromRoute` — the #205 POST repro; asserts form binding **and** that antiforgery stays required by default.
- `FormUpload_WithScalarMetadata_UsesFromFormForNonFileFields` — non-file field → `[FromForm]`.
- `FormUpload_FileCollection_BindsFromForm` — `IFormFileCollection`.
- `FormUpload_DisableAntiforgeryAttribute_EmitsDisableAntiforgery` — per-handler opt-in.
- `FormUpload_AssemblyDisableAntiforgeryDefault_EmitsDisableAntiforgery` — assembly-wide opt-in.
- `FormUpload_HandlerOptOutOverridesAssemblyDefault` — `DisableAntiforgery = false` beats the assembly default.
- `NonFormPost_StillBindsFromBody` — regression guard.

`GenerateEndpointSource` compiles the generated output (`AssertNoCompilationDiagnostics`), so these also verify the emitted form lambda and the opt-in `.DisableAntiforgery()` **type-check** against the ASP.NET Core references. The harness gained `Microsoft.AspNetCore.Http.Features.dll` (defines `IFormFile`) — without it `IFormFile` resolved to an error type and form binding couldn't be exercised at all.

Full suite green (645 tests).

## Docs

- `docs/guide/endpoints.md`: new **File Uploads** section (form binding + the antiforgery warning/opt-in), a `DisableAntiforgery` row in the `[HandlerEndpoint]` properties table, `EndpointDisableAntiforgery` in Global Settings, and a note under **Route Parameters** that explicit `{placeholder}` segments bind from the route (from #232).
- `docs/guide/configuration.md`: `EndpointDisableAntiforgery` added to the `MediatorConfiguration` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)