### PR TITLE
Add named endpoint groups: [MediatorEndpointGroup] + Group reference, group Policies/ExcludeFromDescription

### DIFF
--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -171,6 +171,49 @@ GET   /api/v2/products/{productId}  → GetProduct
 | `RoutePrefix` | Override the route prefix (relative to global prefix; use leading `/` for absolute) |
 | `Tags` | Override the OpenAPI tags (defaults to `Name` as a single tag) |
 | `EndpointFilters` | `IEndpointFilter` types applied to all endpoints in this group |
+| `Policies` | Authorization policy names required by all endpoints (emitted as `.RequireAuthorization("policy")` on the group) |
+| `ExcludeFromDescription` | `true` to hide all endpoints in the group from OpenAPI while keeping them routable |
+
+### `[MediatorEndpointGroup]` — Reusable Named Groups
+
+`[HandlerEndpointGroup]` configures one class. When you want the **same** prefix, tags, filters, policies, and visibility shared across handlers in **different** classes — e.g. an "Admin" area — define the group once at the **assembly** level and reference it by name from any handler:
+
+```csharp
+[assembly: MediatorEndpointGroup(
+    Name = "Admin",
+    RoutePrefix = "/api/v2/admin",
+    Policies = [AuthorizationRoles.GlobalAdminPolicy],
+    EndpointFilters = [typeof(AutoValidationEndpointFilter)],
+    ExcludeFromDescription = true)]
+```
+
+Handlers join the group via `[HandlerEndpoint(Group = "...")]` — no per-class `[HandlerEndpointGroup]` needed:
+
+```csharp
+public class SettingsHandler
+{
+    [HandlerEndpoint(HandlerMethod.Get, "settings", Group = "Admin")]
+    public Result<Settings> Handle(GetSettings query) => ...;   // → GET /api/v2/admin/settings
+}
+```
+
+All endpoints that reference the same group name are mapped under one shared `MapGroup`, inheriting its prefix, tags, filters, and policies.
+
+**Notes:**
+
+- Apply one `[MediatorEndpointGroup]` per named group; multiple are allowed. Definitions are read from the assembly being compiled.
+- Use a **relative** endpoint route (e.g. `"settings"`, not `"/settings"`) so it nests under the group prefix — a leading `/` makes the route absolute and bypasses the prefix.
+- A class-level `[HandlerEndpointGroup]` on the same handler **overrides** the referenced group per-property (most-specific wins); the named group fills any gaps.
+- Referencing a `Group` with no matching `[MediatorEndpointGroup]` definition is not an error — the name is still used as the group name and OpenAPI tag (behaving like an inline group).
+
+| Property | Purpose |
+| --- | --- |
+| `Name` | Group name referenced by `[HandlerEndpoint(Group = "...")]`; also the default OpenAPI tag |
+| `RoutePrefix` | Shared route prefix (relative to global prefix; leading `/` for absolute). Defaults to `Name` kebab-cased |
+| `Tags` | OpenAPI tags (defaults to `Name`) |
+| `EndpointFilters` | `IEndpointFilter` types applied to every endpoint in the group |
+| `Policies` | Authorization policy names required by every endpoint in the group |
+| `ExcludeFromDescription` | `true` to hide the group's endpoints from OpenAPI |
 
 ### `[HandlerEndpoint]` — Customize Individual Endpoints
 
@@ -230,6 +273,7 @@ All properties (including `Method` and `Route`) are also settable as named argum
 | `Summary` | Override XML doc summary for OpenAPI |
 | `Description` | OpenAPI description |
 | `DisplayName` | Pin the ASP.NET Core endpoint display name (logs/diagnostics) via `.WithDisplayName(...)`. Distinct from `Name` (the operationId) |
+| `Group` | Join an assembly-level `[MediatorEndpointGroup(Name = "...")]` by name, inheriting its prefix/tags/filters/policies. See [`[MediatorEndpointGroup]`](#mediatorendpointgroup-reusable-named-groups) |
 | `Tags` | Override the group tags |
 | `Exclude` | `true` to skip endpoint generation entirely |
 | `ExcludeFromDescription` | `true` to hide the endpoint from OpenAPI/API explorers via `.ExcludeFromDescription()` while keeping it routable |

--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -657,6 +657,25 @@ public record UpdateProduct(string ProductId, string? Name, decimal? Price);
 //   { var mergedMessage = message with { ProductId = productId }; ... })
 ```
 
+#### Custom body binding (non-JSON bodies)
+
+For non-standard request bodies — JSON Patch, legacy partial JSON, XML — implement ASP.NET Core's [`IBindableFromHttpContext<TSelf>`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.ibindablefromhttpcontext-1) (or a public static `BindAsync(HttpContext, ParameterInfo)`) on the message type. The generator detects this and **omits `[FromBody]`**, so ASP.NET Core uses your custom binding instead of the default JSON binder (an explicit `[FromBody]` would otherwise take precedence and bypass it):
+
+```csharp
+public record UpdateProjectPatch(...) : IBindableFromHttpContext<UpdateProjectPatch>
+{
+    public static async ValueTask<UpdateProjectPatch?> BindAsync(HttpContext ctx, ParameterInfo p)
+    {
+        // e.g. read a JsonElement / JsonPatchDocument from ctx.Request and build the message
+    }
+}
+// → MapPatch("/{id}", async (string id, UpdateProjectPatch message, ...) => ...)  // no [FromBody]
+```
+
+To document a non-default request schema/content type in OpenAPI, implement [`IEndpointParameterMetadataProvider.PopulateMetadata`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.metadata.iendpointparametermetadataprovider) on that same type so the bound type stays the single source of truth for both binding and documentation. Listing multiple [`AcceptsContentTypes`](#handlerendpoint-customize-individual-endpoints) makes the runtime content-type matcher accept all of them. Route parameters still merge into the custom-bound message as usual.
+
+> Custom binding applies to body-bound `POST`/`PUT`/`PATCH` endpoints. For `GET`/`DELETE`, properties bind from route/query via `[AsParameters]` — write a hand-mapped minimal API for the rare custom-binding case there.
+
 ### File Uploads
 
 When a POST/PUT/PATCH message exposes an `IFormFile`, `IFormFileCollection`, or `IFormCollection` property, the whole message binds from `multipart/form-data` instead of the JSON body. File properties bind by name (no attribute — how Minimal APIs bind `IFormFile`), any other fields bind with `[FromForm]`, and route placeholders still bind from the route:

--- a/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
@@ -117,6 +117,19 @@ public sealed class HandlerEndpointAttribute : Attribute
     public string? DisplayName { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the endpoint group this handler joins. Resolves against an
+    /// assembly-level <c>[MediatorEndpointGroup(Name = "...")]</c> definition, inheriting that
+    /// group's route prefix, tags, filters, policies, and description visibility.
+    /// <para>
+    /// When no matching group definition exists, the value is still used as the group name and
+    /// OpenAPI tag (behaving like an inline group). A class-level
+    /// <see cref="HandlerEndpointGroupAttribute"/> takes precedence over the referenced group for
+    /// any property it sets.
+    /// </para>
+    /// </summary>
+    public string? Group { get; set; }
+
+    /// <summary>
     /// Gets or sets the tags for grouping endpoints in OpenAPI.
     /// When null, uses the HandlerEndpointGroup attribute's Name property.
     /// </summary>

--- a/src/Foundatio.Mediator.Abstractions/HandlerEndpointGroupAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/HandlerEndpointGroupAttribute.cs
@@ -52,4 +52,16 @@ public sealed class HandlerEndpointGroupAttribute : Attribute
     /// These filters are additive to any global-level filters and run before endpoint-level filters.
     /// </summary>
     public Type[]? EndpointFilters { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authorization policy names required by every endpoint in this group.
+    /// Emitted as <c>.RequireAuthorization("policy")</c> on the group.
+    /// </summary>
+    public string[]? Policies { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether endpoints in this group are hidden from the OpenAPI description
+    /// (via <c>.ExcludeFromDescription()</c> on the group) while remaining routable.
+    /// </summary>
+    public bool ExcludeFromDescription { get; set; }
 }

--- a/src/Foundatio.Mediator.Abstractions/MediatorEndpointGroupAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/MediatorEndpointGroupAttribute.cs
@@ -1,0 +1,81 @@
+namespace Foundatio.Mediator;
+
+/// <summary>
+/// Defines a reusable, named endpoint group at the assembly level. Handlers join the group by
+/// referencing its <see cref="Name"/> via <c>[HandlerEndpoint(Group = "...")]</c>, and inherit the
+/// group's route prefix, OpenAPI tags, endpoint filters, authorization policies, and description
+/// visibility — without each handler class needing its own <see cref="HandlerEndpointGroupAttribute"/>.
+/// </summary>
+/// <remarks>
+/// Apply one attribute per named group. Group definitions are read from the assembly being compiled.
+/// <example>
+/// <code>
+/// [assembly: MediatorEndpointGroup(
+///     Name = "Admin",
+///     RoutePrefix = "/api/v2/admin",
+///     Policies = [AuthorizationRoles.GlobalAdminPolicy],
+///     EndpointFilters = [typeof(AutoValidationEndpointFilter)],
+///     ExcludeFromDescription = true)]
+///
+/// public class SettingsHandler
+/// {
+///     [HandlerEndpoint(HandlerMethod.Get, "settings", Group = "Admin")]
+///     public Result&lt;Settings&gt; Handle(GetSettings query) => ...;
+/// }
+/// </code>
+/// </example>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)]
+public sealed class MediatorEndpointGroupAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MediatorEndpointGroupAttribute"/> class.
+    /// </summary>
+    public MediatorEndpointGroupAttribute() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MediatorEndpointGroupAttribute"/> class.
+    /// </summary>
+    /// <param name="name">The group name referenced by <c>[HandlerEndpoint(Group = "...")]</c>.</param>
+    public MediatorEndpointGroupAttribute(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>
+    /// Gets or sets the group name. Handlers reference this value via
+    /// <c>[HandlerEndpoint(Group = "...")]</c>. Also used as the default OpenAPI tag.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the route prefix shared by all endpoints in this group, relative to the global
+    /// <c>EndpointRoutePrefix</c>. Use a leading <c>/</c> for an absolute prefix that bypasses the
+    /// global prefix. When null, the prefix is derived from <see cref="Name"/> (kebab-cased).
+    /// </summary>
+    public string? RoutePrefix { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OpenAPI tags for endpoints in this group. When null, <see cref="Name"/> is
+    /// used as a single tag.
+    /// </summary>
+    public string[]? Tags { get; set; }
+
+    /// <summary>
+    /// Gets or sets the endpoint filter types applied to every endpoint in this group.
+    /// Each type must implement <c>Microsoft.AspNetCore.Http.IEndpointFilter</c>.
+    /// </summary>
+    public Type[]? EndpointFilters { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authorization policy names required by every endpoint in this group.
+    /// Emitted as <c>.RequireAuthorization("policy")</c> on the group.
+    /// </summary>
+    public string[]? Policies { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether endpoints in this group are hidden from the OpenAPI description
+    /// (via <c>.ExcludeFromDescription()</c> on the group) while remaining routable.
+    /// </summary>
+    public bool ExcludeFromDescription { get; set; }
+}

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -394,9 +394,22 @@ internal static class EndpointGenerator
 
             // Add Group-level auth if the group requires auth (and global doesn't already)
             var groupRequireAuth = firstEndpoint.RequireAuth && !endpointDefaults.RequireAuth;
-            if (groupRequireAuth && !firstEndpoint.Policies.Any() && !firstEndpoint.Roles.Any())
+            var groupPolicies = firstEndpoint.GroupPolicies;
+            if (groupRequireAuth && !firstEndpoint.Policies.Any() && !firstEndpoint.Roles.Any() && !groupPolicies.Any())
             {
                 source.Append(".RequireAuthorization()");
+            }
+
+            // Add group-level authorization policies from [HandlerEndpointGroup]/[MediatorEndpointGroup]
+            foreach (var policy in groupPolicies)
+            {
+                source.Append($".RequireAuthorization(\"{policy}\")");
+            }
+
+            // Hide the whole group from OpenAPI when requested
+            if (firstEndpoint.GroupExcludeFromDescription)
+            {
+                source.Append(".ExcludeFromDescription()");
             }
 
             source.AppendLine(";");
@@ -437,7 +450,7 @@ internal static class EndpointGenerator
                     ? "endpoints"
                     : groupVarName;
 
-                GenerateEndpoint(source, handler, targetGroup, hasAsParametersAttribute, hasFromBodyAttribute, hasWithOpenApi, groupRequireAuth || endpointDefaults.RequireAuth, assemblySuffix, endpointDefaults.SummaryStyle, endpointDefaults.Conventions, endpointDefaults.DisableAntiforgery, routeOverride);
+                GenerateEndpoint(source, handler, targetGroup, hasAsParametersAttribute, hasFromBodyAttribute, hasWithOpenApi, groupRequireAuth || endpointDefaults.RequireAuth || groupPolicies.Any(), assemblySuffix, endpointDefaults.SummaryStyle, endpointDefaults.Conventions, endpointDefaults.DisableAntiforgery, routeOverride);
 
                 // Collect endpoint info for logging
                 var endpointRoute = routeOverride ?? handler.Endpoint!.Value.Route;

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -939,7 +939,10 @@ internal static class EndpointGenerator
         {
             var routeParams = endpoint.RouteParameters;
             var bindingParams = endpoint.BindingParameters;
-            var fromBodyAttr = hasFromBodyAttribute ? "[Microsoft.AspNetCore.Mvc.FromBody] " : "";
+            // Omit [FromBody] when the message type defines its own minimal-API binding
+            // (IBindableFromHttpContext / static BindAsync). Explicit [FromBody] has higher binding
+            // precedence than BindAsync, so emitting it would silently bypass the custom binding.
+            var fromBodyAttr = (hasFromBodyAttribute && !endpoint.MessageHasCustomBinding) ? "[Microsoft.AspNetCore.Mvc.FromBody] " : "";
             var allMergeParams = routeParams.Concat(bindingParams).ToList();
 
             if (allMergeParams.Count > 0)

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -576,20 +576,33 @@ internal static class HandlerAnalyzer
             }
         }
 
-        // Extract group info from [HandlerEndpointGroup]
-        string? groupName = null;
-        string? groupRoutePrefix = null;
-        string[]? groupTags = null;
+        // Resolve the endpoint group. A handler joins a group via a class-level [HandlerEndpointGroup]
+        // and/or by referencing an assembly-level [MediatorEndpointGroup] by name through
+        // [HandlerEndpoint(Group = "...")]. Class-level settings take precedence per-property; the
+        // referenced named group fills the gaps.
+        var groupRef = GetStringProperty(methodEndpointAttr, "Group") ??
+                       GetStringProperty(classEndpointAttr, "Group");
 
-        if (groupAttr != null)
+        AttributeData? namedGroupAttr = null;
+        if (!string.IsNullOrEmpty(groupRef))
         {
-            // Group name from constructor argument or named property
-            if (groupAttr.ConstructorArguments.Length > 0)
-                groupName = groupAttr.ConstructorArguments[0].Value as string;
-            groupName ??= GetStringProperty(groupAttr, "Name");
-            groupRoutePrefix = GetStringProperty(groupAttr, "RoutePrefix");
-            groupTags = GetStringArrayProperty(groupAttr, "Tags");
+            namedGroupAttr = compilation.Assembly.GetAttributes().FirstOrDefault(a =>
+                a.AttributeClass?.ToDisplayString() == WellKnownTypes.MediatorEndpointGroupAttribute &&
+                string.Equals(GetGroupAttributeName(a), groupRef, StringComparison.Ordinal));
         }
+
+        var classGroup = ReadGroupSettings(groupAttr);
+        var namedGroup = ReadGroupSettings(namedGroupAttr);
+
+        // A handler is "in a group" when it has a class group attribute, resolves a named group, or
+        // references a group by name (an unresolved reference behaves like an inline named group).
+        bool hasGroup = groupAttr != null || namedGroupAttr != null || !string.IsNullOrEmpty(groupRef);
+
+        string? groupName = classGroup.Name ?? namedGroup.Name ?? groupRef;
+        string? groupRoutePrefix = classGroup.RoutePrefix ?? namedGroup.RoutePrefix;
+        string[]? groupTags = classGroup.Tags ?? namedGroup.Tags;
+        var groupPolicies = classGroup.Policies ?? namedGroup.Policies ?? [];
+        var groupExcludeFromDescription = classGroup.ExcludeFromDescription ?? namedGroup.ExcludeFromDescription ?? false;
 
         // Extract endpoint info (method takes precedence over class)
         // Extract streaming configuration
@@ -650,7 +663,7 @@ internal static class HandlerAnalyzer
             HandlerMethodCount = handlerMethodCount,
             RouteParams = routeParams.Select(p => new RouteParam(p.Name, p.Type.QualifiedName)).ToArray(),
             GlobalRoutePrefix = "",
-            HasGroupAttribute = groupAttr != null,
+            HasGroupAttribute = hasGroup,
             GroupName = groupName,
             GroupRoutePrefix = groupRoutePrefix,
             HttpMethodEnum = httpMethodEnum,
@@ -703,7 +716,7 @@ internal static class HandlerAnalyzer
         var methodFilters = GetTypeArrayProperty(methodEndpointAttr, "EndpointFilters");
         var classFilters = GetTypeArrayProperty(classEndpointAttr, "EndpointFilters");
         var endpointFilters = (methodFilters ?? []).Concat(classFilters ?? []).Distinct().ToArray();
-        var groupFilters = GetTypeArrayProperty(groupAttr, "EndpointFilters") ?? [];
+        var groupFilters = classGroup.Filters ?? namedGroup.Filters ?? [];
 
         // Extract endpoint convention attributes (IEndpointConvention<TBuilder>)
         var conventions = ExtractEndpointConventions(classSymbol, handlerMethod, compilation);
@@ -809,6 +822,8 @@ internal static class HandlerAnalyzer
             Group = groupName ?? tags?.FirstOrDefault(),
             GroupTags = new(groupTags ?? []),
             GroupRoutePrefix = groupRoutePrefix,
+            GroupPolicies = new(groupPolicies),
+            GroupExcludeFromDescription = groupExcludeFromDescription,
             GroupBypassGlobalPrefix = groupBypassGlobalPrefix,
             RouteBypassPrefixes = routeBypassPrefixes,
             RouteParameters = new(routeParams),
@@ -1414,6 +1429,46 @@ internal static class HandlerAnalyzer
 
         // Direct return type (not Result, not void)
         return unwrapped.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    }
+
+    /// <summary>
+    /// Group settings read from a <c>[HandlerEndpointGroup]</c> (class) or <c>[MediatorEndpointGroup]</c>
+    /// (assembly) attribute. Both expose the same property names, so the same reader handles both.
+    /// </summary>
+    private readonly record struct GroupSettings(
+        string? Name,
+        string? RoutePrefix,
+        string[]? Tags,
+        string[]? Filters,
+        string[]? Policies,
+        bool? ExcludeFromDescription);
+
+    /// <summary>
+    /// Gets the group name from an attribute's constructor argument or its <c>Name</c> property.
+    /// </summary>
+    private static string? GetGroupAttributeName(AttributeData attr)
+    {
+        if (attr.ConstructorArguments.Length > 0 && attr.ConstructorArguments[0].Value is string ctorName)
+            return ctorName;
+        return GetStringProperty(attr, "Name");
+    }
+
+    /// <summary>
+    /// Reads group settings from a class-level or assembly-level group attribute. Returns an empty
+    /// <see cref="GroupSettings"/> (all nulls) when <paramref name="attr"/> is null.
+    /// </summary>
+    private static GroupSettings ReadGroupSettings(AttributeData? attr)
+    {
+        if (attr == null)
+            return default;
+
+        return new GroupSettings(
+            GetGroupAttributeName(attr),
+            GetStringProperty(attr, "RoutePrefix"),
+            GetStringArrayProperty(attr, "Tags"),
+            GetTypeArrayProperty(attr, "EndpointFilters"),
+            GetStringArrayProperty(attr, "Policies"),
+            GetBoolProperty(attr, "ExcludeFromDescription"));
     }
 
     /// <summary>

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -809,6 +809,10 @@ internal static class HandlerAnalyzer
             }
         }
 
+        // When the body-bound message type defines its own minimal-API binding, the generator must
+        // omit [FromBody] (which would otherwise preempt it by binding precedence).
+        bool messageHasCustomBinding = bindFromBody && MessageDefinesCustomBinding(messageType, compilation);
+
         return new EndpointInfo
         {
             HttpMethod = httpMethod,
@@ -831,6 +835,7 @@ internal static class HandlerAnalyzer
             BindingParameters = new(bindingParams),
             FormParameters = new(formParams),
             BindFromBody = bindFromBody,
+            MessageHasCustomBinding = messageHasCustomBinding,
             BindFromForm = bindFromForm,
             DisableAntiforgery = disableAntiforgery,
             SupportsAsParameters = supportsAsParameters,
@@ -1442,6 +1447,27 @@ internal static class HandlerAnalyzer
         string[]? Filters,
         string[]? Policies,
         bool? ExcludeFromDescription);
+
+    /// <summary>
+    /// Determines whether a message type defines its own minimal-API custom binding: it implements
+    /// <c>Microsoft.AspNetCore.Http.IBindableFromHttpContext&lt;TSelf&gt;</c> or declares a public
+    /// static <c>BindAsync</c> method. ASP.NET Core checks these (binding-precedence rule 3) only when
+    /// the parameter is not already pinned by an explicit <c>[FromBody]</c>.
+    /// </summary>
+    private static bool MessageDefinesCustomBinding(INamedTypeSymbol messageType, Compilation compilation)
+    {
+        var bindableInterface = compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Http.IBindableFromHttpContext`1");
+        if (bindableInterface != null &&
+            messageType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, bindableInterface)))
+        {
+            return true;
+        }
+
+        // Non-interface form: a valid public static BindAsync method on the type.
+        return messageType.GetMembers("BindAsync")
+            .OfType<IMethodSymbol>()
+            .Any(m => m.IsStatic && m.DeclaredAccessibility == Accessibility.Public);
+    }
 
     /// <summary>
     /// Gets the group name from an attribute's constructor argument or its <c>Name</c> property.

--- a/src/Foundatio.Mediator/Models/EndpointInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointInfo.cs
@@ -65,6 +65,18 @@ internal readonly record struct EndpointInfo
     public string? GroupRoutePrefix { get; init; }
 
     /// <summary>
+    /// Authorization policy names required by the group (emitted as <c>.RequireAuthorization("policy")</c>
+    /// on the group). From <c>[HandlerEndpointGroup]</c> or a referenced <c>[MediatorEndpointGroup]</c>.
+    /// </summary>
+    public EquatableArray<string> GroupPolicies { get; init; }
+
+    /// <summary>
+    /// When true, the group is hidden from the OpenAPI description via <c>.ExcludeFromDescription()</c>
+    /// on the group builder while remaining routable.
+    /// </summary>
+    public bool GroupExcludeFromDescription { get; init; }
+
+    /// <summary>
     /// Route parameters extracted from the message type properties.
     /// </summary>
     public EquatableArray<EndpointParameterInfo> RouteParameters { get; init; }

--- a/src/Foundatio.Mediator/Models/EndpointInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointInfo.cs
@@ -98,6 +98,14 @@ internal readonly record struct EndpointInfo
     public bool BindFromBody { get; init; }
 
     /// <summary>
+    /// Whether the body-bound message type defines its own minimal-API custom binding
+    /// (implements <c>IBindableFromHttpContext&lt;TSelf&gt;</c> or declares a public static
+    /// <c>BindAsync</c> method). When true, the generated endpoint omits <c>[FromBody]</c> so
+    /// ASP.NET Core uses the type's custom binding instead of JSON body binding.
+    /// </summary>
+    public bool MessageHasCustomBinding { get; init; }
+
+    /// <summary>
     /// Whether the message should be bound from a multipart/form-data request.
     /// Set when a POST/PUT/PATCH message exposes an <c>IFormFile</c>/<c>IFormFileCollection</c>/<c>IFormCollection</c>
     /// property. Mutually exclusive with <see cref="BindFromBody"/>; the endpoint also emits <c>.DisableAntiforgery()</c>.

--- a/src/Foundatio.Mediator/Utility/TypeExtensions.cs
+++ b/src/Foundatio.Mediator/Utility/TypeExtensions.cs
@@ -267,6 +267,7 @@ internal static class WellKnownTypes
     public const string CallContext = "Foundatio.Mediator.CallContext";
     public const string HandlerEndpointAttribute = "Foundatio.Mediator.HandlerEndpointAttribute";
     public const string HandlerEndpointGroupAttribute = "Foundatio.Mediator.HandlerEndpointGroupAttribute";
+    public const string MediatorEndpointGroupAttribute = "Foundatio.Mediator.MediatorEndpointGroupAttribute";
     public const string UseMiddlewareAttribute = "Foundatio.Mediator.UseMiddlewareAttribute";
     public const string MediatorConfigurationAttribute = "Foundatio.Mediator.MediatorConfigurationAttribute";
     public const string AllowAnonymousAttribute = "Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute";

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -1602,6 +1602,142 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
     }
 
     [Fact]
+    public void NamedGroup_ReferencedByHandlerEndpoint_AppliesGroupSettings()
+    {
+        var source = """
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+            [assembly: MediatorEndpointGroup(
+                Name = "Admin",
+                RoutePrefix = "/api/v2/admin",
+                Policies = ["GlobalAdmin"],
+                EndpointFilters = new[] { typeof(MyAdminFilter) },
+                ExcludeFromDescription = true)]
+
+            public class MyAdminFilter : IEndpointFilter
+            {
+                public ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next) => next(context);
+            }
+
+            public record GetSettings();
+
+            public class SettingsHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Get, "settings", Group = "Admin")]
+                public string Handle(GetSettings query) => "ok";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        // The group MapGroup uses the named-group prefix and tag
+        Assert.Contains("MapGroup(\"/api/v2/admin\")", endpointSource);
+        Assert.Contains(".WithTags(\"Admin\")", endpointSource);
+        // Group policy, hidden-from-description, and filter all come from the named group
+        Assert.Contains(".RequireAuthorization(\"GlobalAdmin\")", endpointSource);
+        Assert.Contains(".ExcludeFromDescription()", endpointSource);
+        Assert.Contains("AddEndpointFilter<global::MyAdminFilter>()", endpointSource);
+    }
+
+    [Fact]
+    public void ClassGroup_PoliciesAndExcludeFromDescription_EmittedOnGroup()
+    {
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record GetWidget(string Id);
+
+            [HandlerEndpointGroup("Widgets", Policies = ["WidgetReader"], ExcludeFromDescription = true)]
+            public class WidgetHandler
+            {
+                public string Handle(GetWidget query) => "widget";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.Contains("MapGroup(\"widgets\")", endpointSource);
+        Assert.Contains(".RequireAuthorization(\"WidgetReader\")", endpointSource);
+        Assert.Contains(".ExcludeFromDescription()", endpointSource);
+    }
+
+    [Fact]
+    public void GroupReference_WithoutDefinition_BehavesAsInlineGroup()
+    {
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record GetThing();
+
+            public class ThingHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Get, "list", Group = "Reports")]
+                public string Handle(GetThing query) => "thing";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        // No assembly definition, but Group = "Reports" still names + tags the group (kebab prefix).
+        Assert.Contains("MapGroup(\"reports\")", endpointSource);
+        Assert.Contains(".WithTags(\"Reports\")", endpointSource);
+    }
+
+    [Fact]
+    public void ClassGroup_OverridesNamedGroup_PerProperty()
+    {
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+            [assembly: MediatorEndpointGroup(Name = "Admin", RoutePrefix = "/api/admin", Policies = ["NamedPolicy"])]
+
+            public record GetX();
+
+            [HandlerEndpointGroup("Admin", RoutePrefix = "custom-admin")]
+            public class XHandler
+            {
+                [HandlerEndpoint(Group = "Admin")]
+                public string Handle(GetX query) => "x";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        // Class-level RoutePrefix wins over the named group's prefix.
+        Assert.Contains("MapGroup(\"custom-admin\")", endpointSource);
+        Assert.DoesNotContain("MapGroup(\"/api/admin\")", endpointSource);
+        // Policy is inherited from the named group (class group didn't set one).
+        Assert.Contains(".RequireAuthorization(\"NamedPolicy\")", endpointSource);
+    }
+
+    [Fact]
     public void AutoDetect_NonGenericResult_EmitsProducesProblem()
     {
         var source = """

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -1196,6 +1196,114 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
     }
 
     [Fact]
+    public void CustomBindingMessage_IBindableFromHttpContext_OmitsFromBody()
+    {
+        var source = """
+            using System.Reflection;
+            using System.Threading.Tasks;
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public class CreateThing : IBindableFromHttpContext<CreateThing>
+            {
+                public string Name { get; set; } = "";
+                public static ValueTask<CreateThing?> BindAsync(HttpContext context, ParameterInfo parameter)
+                    => ValueTask.FromResult<CreateThing?>(new CreateThing());
+            }
+
+            public class ThingHandler
+            {
+                public string Handle(CreateThing command) => "ok";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        // The message binds via its own BindAsync, so [FromBody] must NOT preempt it.
+        Assert.DoesNotContain("FromBody", endpointSource);
+        // The message is still bound as a lambda parameter.
+        Assert.Contains("CreateThing message", endpointSource);
+    }
+
+    [Fact]
+    public void CustomBindingMessage_StaticBindAsyncWithoutInterface_OmitsFromBody()
+    {
+        var source = """
+            using System.Reflection;
+            using System.Threading.Tasks;
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public class CreateGadget
+            {
+                public string Name { get; set; } = "";
+                public static ValueTask<CreateGadget?> BindAsync(HttpContext context, ParameterInfo parameter)
+                    => ValueTask.FromResult<CreateGadget?>(new CreateGadget());
+            }
+
+            public class GadgetHandler
+            {
+                public string Handle(CreateGadget command) => "ok";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.DoesNotContain("FromBody", endpointSource);
+        Assert.Contains("CreateGadget message", endpointSource);
+    }
+
+    [Fact]
+    public void CustomBindingMessage_WithRouteParam_OmitsFromBodyAndMergesRoute()
+    {
+        var source = """
+            using System.Reflection;
+            using System.Threading.Tasks;
+            using Foundatio.Mediator;
+            using Microsoft.AspNetCore.Http;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record UpdateThing(string Id, string Name) : IBindableFromHttpContext<UpdateThing>
+            {
+                public static ValueTask<UpdateThing?> BindAsync(HttpContext context, ParameterInfo parameter)
+                    => ValueTask.FromResult<UpdateThing?>(new UpdateThing("", ""));
+            }
+
+            public class ThingHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Put, "things/{id}")]
+                public string Handle(UpdateThing command) => "ok";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.DoesNotContain("FromBody", endpointSource);
+        // Route param still merged into the custom-bound message.
+        Assert.Contains("message with { Id = id }", endpointSource);
+    }
+
+    [Fact]
     public void ActionVerbMismatchedEntity_PreservesEntityInRoute()
     {
         var source = """


### PR DESCRIPTION
Second of the phased endpoint-metadata improvements (item #6).

> **Stacked on [#234](https://github.com/FoundatioFx/Foundatio.Mediator/pull/234)** — base branch is `feat/endpoint-metadata-quick-wins` so the diff stays clean (both PRs touch the same files). Rebase onto `main` once #234 merges.

## What's in this PR

### `[MediatorEndpointGroup]` — reusable named groups (new, assembly-level)
Define a group once and share its prefix/tags/filters/policies/visibility across handlers in **different** classes:

```csharp
[assembly: MediatorEndpointGroup(
    Name = "Admin",
    RoutePrefix = "/api/v2/admin",
    Policies = [AuthorizationRoles.GlobalAdminPolicy],
    EndpointFilters = [typeof(AutoValidationEndpointFilter)],
    ExcludeFromDescription = true)]

public class SettingsHandler
{
    [HandlerEndpoint(HandlerMethod.Get, "settings", Group = "Admin")]
    public Result<Settings> Handle(GetSettings query) => ...;   // → GET /api/v2/admin/settings
}
```

`[HandlerEndpoint(Group = "...")]` joins a handler to the named group — no per-class `[HandlerEndpointGroup]` needed. All handlers referencing the same name map under one shared `MapGroup`. This is the seam that lets the admin/legacy areas drop their hand-written minimal-API glue.

### `Policies` + `ExcludeFromDescription` on groups
Added to **both** the new `[MediatorEndpointGroup]` and the existing class-level `[HandlerEndpointGroup]`. Emitted on the group builder:
- `Policies` → `.RequireAuthorization("policy")` per policy
- `ExcludeFromDescription` → `.ExcludeFromDescription()` (hides the whole group from OpenAPI, still routable)

## Design notes
- **Merge precedence:** a class-level `[HandlerEndpointGroup]` overrides the referenced named group per-property (most-specific wins); the named group fills gaps.
- **Graceful degradation:** referencing a `Group` with no matching definition is not an error — the value is used as the group name/tag (inline group), so there's no silent drop to the default group.
- **Routes:** use a *relative* endpoint route (`"settings"`, not `"/settings"`) to nest under the group prefix — a leading `/` is absolute and bypasses the prefix (existing convention).
- **Scope:** group definitions are read from the compiled assembly's attributes. Cross-assembly group sharing is intentionally out of scope here.

## Testing
- `dotnet test` → **662 passing** (+4 new generator tests), 0 failures.
- New coverage: named group applies prefix/tag/policy/filter/exclude; class-level group policies + exclude; unresolved `Group` reference behaves as an inline group; class group overrides named group per-property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)