### PR TITLE
Don't lift *Id props into route/query params for body commands with explicit routes

### DIFF
--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -511,19 +511,46 @@ For internal APIs or rapid prototyping, convention-based routes are ideal.
 
 ### Route Parameters
 
-Properties named `Id` or ending with `Id` automatically become route parameters:
+Properties named `Id` or ending with `Id` automatically become route parameters **when the route is generated** (no explicit template):
 
 ```csharp
 public record GetProduct(string ProductId);
 // → GET /api/products/{productId}
 ```
 
-With an **explicit route template**, any property whose name matches a `{placeholder}` segment binds from the route — even when it isn't named `Id`, and for any HTTP method. Inline constraints (`{number:int}`) are matched too:
+With an **explicit route template**, a property binds from the route only when its name matches a `{placeholder}` segment (or it carries `[FromRoute]`) — even when it isn't named `Id`, and for any HTTP method. Inline constraints (`{number:int}`) are matched too:
 
 ```csharp
 [HandlerEndpoint(HandlerMethod.Get, "contracts/{contractNumber}")]
 public Result<Contract> Handle(GetContract query);   // record GetContract(string ContractNumber)
 // → contractNumber binds from the path, not the query string
+```
+
+The `Id`-suffix convention does **not** apply to an explicit template that lacks the matching placeholder. An `*Id` property with no `{placeholder}` stays where it belongs — in the request body for POST/PUT/PATCH, or a query parameter for GET/DELETE — instead of being lifted into a phantom parameter the client never supplies:
+
+```csharp
+public record ExternalLogin(string ExternalId, string Provider);
+
+[HandlerEndpoint(HandlerMethod.Post, "external-login")]   // no {externalId} segment
+public Result Handle(ExternalLogin command);
+// → the whole ExternalLogin (including ExternalId) binds from the JSON body
+```
+
+### Binding the Whole Message From the Body
+
+For a body command (POST/PUT/PATCH), apply `[FromBody]` to the handler's **message parameter** to bind the entire message from the request body and opt out of the `Id`-suffix route/query conventions — even when the route is generated. Explicit `{placeholder}` segments and `[FromRoute]`/`[FromQuery]`/`[FromHeader]` property attributes are still honored.
+
+```csharp
+using Microsoft.AspNetCore.Mvc;
+
+public record ApproveOrder(string OrderId, string? Comment);
+
+public class OrderHandler
+{
+    // Without [FromBody]: POST /api/orders/{orderId}/approve, OrderId lifted into the route.
+    // With    [FromBody]: OrderId (and everything else) binds from the body.
+    public Result Handle([FromBody] ApproveOrder command) => Result.Success();
+}
 ```
 
 ### Query Parameters

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -638,8 +638,17 @@ internal static class HandlerAnalyzer
             _ => isStreaming ? "GET" : InferHttpMethod(messageType.Name)
         };
 
+        // Honor an explicit [FromBody] on the handler's message parameter as an opt-out from the
+        // route/query binding conventions: the whole message binds from the request body and no
+        // properties are lifted into route/query parameters. Explicit {placeholder} segments and
+        // [FromRoute]/[FromQuery]/[FromHeader] property attributes are still honored, since those
+        // express deliberate intent to bind a value from somewhere other than the body.
+        bool explicitFromBody = handlerMethod.Parameters.Length > 0 &&
+            handlerMethod.Parameters[0].GetAttributes().Any(a =>
+                a.AttributeClass?.ToDisplayString() == "Microsoft.AspNetCore.Mvc.FromBodyAttribute");
+
         // Analyze message type for parameters (before route computation, since route params go into the shared input)
-        var (routeParams, queryParams, bindingParams, formParams, bindFromForm, supportsAsParameters, hasParameterlessConstructor) = AnalyzeMessageParameters(messageType, httpMethod, compilation, isActionVerb: actionVerb != null, explicitRoute: explicitRoute);
+        var (routeParams, queryParams, bindingParams, formParams, bindFromForm, supportsAsParameters, hasParameterlessConstructor) = AnalyzeMessageParameters(messageType, httpMethod, compilation, isActionVerb: actionVerb != null, explicitRoute: explicitRoute, bindWholeMessageFromBody: explicitFromBody);
 
         // ── Shared route computation ───────────────────────────────
         // Uses the same code path as MediatorInfoAnalyzer (FMED017 diagnostic).
@@ -736,9 +745,16 @@ internal static class HandlerAnalyzer
         // not from a JSON body, so the two are mutually exclusive.
         bool bindFromBody = (httpMethod is "POST" or "PUT" or "PATCH") && !bindFromForm;
 
+        // An explicit [FromBody] on the message parameter forces whole-message body binding
+        // regardless of HTTP method, and below it suppresses the "all properties covered by the
+        // route → skip body" shortcuts. It never overrides form binding (IFormFile messages
+        // cannot be deserialized from a JSON body).
+        if (explicitFromBody && !bindFromForm)
+            bindFromBody = true;
+
         // For auto-generated action verb routes, check if all properties are already
         // covered by route params (IDs). If so, skip body binding.
-        if (bindFromBody && actionVerb != null && !hasExplicitRoute)
+        if (bindFromBody && !explicitFromBody && actionVerb != null && !hasExplicitRoute)
         {
             var allProperties = messageType.GetMembers()
                 .OfType<IPropertySymbol>()
@@ -753,8 +769,10 @@ internal static class HandlerAnalyzer
         }
 
         // If we have an explicit route with placeholders that cover all message properties,
-        // skip body binding — all data comes from the route (e.g., POST /{todoId}/complete)
-        if (bindFromBody && hasExplicitRoute && !string.IsNullOrEmpty(route))
+        // skip body binding — all data comes from the route (e.g., POST /{todoId}/complete).
+        // An explicit [FromBody] opts out of this: the message binds from the body even when the
+        // route could cover every property.
+        if (bindFromBody && !explicitFromBody && hasExplicitRoute && !string.IsNullOrEmpty(route))
         {
             var allProperties = messageType.GetMembers()
                 .OfType<IPropertySymbol>()
@@ -979,7 +997,7 @@ internal static class HandlerAnalyzer
     /// Analyzes message type properties to determine route and query parameters.
     /// </summary>
     private static (EndpointParameterInfo[] routeParams, EndpointParameterInfo[] queryParams, EndpointParameterInfo[] bindingParams, EndpointParameterInfo[] formParams, bool bindFromForm, bool supportsAsParameters, bool hasParameterlessConstructor)
-        AnalyzeMessageParameters(INamedTypeSymbol messageType, string httpMethod, Compilation compilation, bool isActionVerb = false, string? explicitRoute = null)
+        AnalyzeMessageParameters(INamedTypeSymbol messageType, string httpMethod, Compilation compilation, bool isActionVerb = false, string? explicitRoute = null, bool bindWholeMessageFromBody = false)
     {
         var routeParams = new List<EndpointParameterInfo>();
         var queryParams = new List<EndpointParameterInfo>();
@@ -990,6 +1008,12 @@ internal static class HandlerAnalyzer
         var routePlaceholders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var placeholder in RouteConventions.ExtractRoutePlaceholderNames(explicitRoute))
             routePlaceholders.Add(placeholder);
+
+        // True when the handler supplied a literal route template. The *Id → route-parameter
+        // convention below only weaves a {placeholder} into a *generated* route; with an explicit
+        // template the route string is taken verbatim, so the convention must not run (matches
+        // RouteConventions.ComputeEndpointRouteInfo's HasExplicitRoute definition).
+        bool hasExplicitRoute = !string.IsNullOrEmpty(explicitRoute);
 
         // Check if message supports [AsParameters] binding
         // It needs a parameterless constructor or a record with optional parameters
@@ -1065,12 +1089,22 @@ internal static class HandlerAnalyzer
 
             // For GET/DELETE/PUT/PATCH, ID properties become route parameters.
             // For action verbs (POST), IDs are also promoted to route params
-            // (e.g., CompleteTodo(string TodoId) → POST /todos/{todoId}/complete)
-            if (isIdProperty && (httpMethod is "GET" or "DELETE" or "PUT" or "PATCH" || isActionVerb))
+            // (e.g., CompleteTodo(string TodoId) → POST /todos/{todoId}/complete).
+            //
+            // This convention only applies when the route is generated. With an explicit route
+            // template, an *Id property is bound from the route only when it appears as a
+            // {placeholder} (handled above) or carries [FromRoute]. Promoting it here would emit a
+            // phantom route/query parameter the body client never supplies — a required-query 400
+            // for non-nullable types, or a silent null overwrite of the body value for nullable
+            // ones — so the property must instead fall through to query (GET/DELETE) or body binding.
+            //
+            // An explicit [FromBody] on the message (bindWholeMessageFromBody) opts out of both
+            // conventions entirely: every remaining property stays in the body.
+            if (isIdProperty && !hasExplicitRoute && !bindWholeMessageFromBody && (httpMethod is "GET" or "DELETE" or "PUT" or "PATCH" || isActionVerb))
             {
                 routeParams.Add(paramInfo with { IsRouteParameter = true });
             }
-            else if (httpMethod is "GET" or "DELETE")
+            else if (!bindWholeMessageFromBody && httpMethod is "GET" or "DELETE")
             {
                 // Non-ID properties become query parameters for GET/DELETE
                 queryParams.Add(paramInfo with { IsRouteParameter = false });

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -1068,6 +1068,116 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
     }
 
     [Fact]
+    public void PostWithExplicitRoute_IdPropertyNotInTemplate_BindsWholeMessageFromBody()
+    {
+        // Regression: an *Id property on a body command must NOT be lifted into a route/query
+        // parameter when the explicit route template has no matching {placeholder}. Doing so
+        // emitted a phantom query param (required → 400 for non-nullable, silent null overwrite
+        // for nullable) instead of binding the value from the JSON body.
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record ExternalLogin(string ExternalId, string Provider);
+
+            public class AuthHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Post, "external-login")]
+                public Result Handle(ExternalLogin command) => Result.Success();
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.Contains("MapPost", endpointSource);
+        Assert.Contains("external-login", endpointSource);
+        // ExternalId is not a {placeholder} → it must stay in the body, not become a lifted param.
+        Assert.DoesNotContain("externalId", endpointSource);
+        // No "message with { ExternalId = externalId }" merge that would overwrite the body value.
+        Assert.DoesNotContain("message with", endpointSource);
+        // It must not be promoted to a query parameter either.
+        Assert.DoesNotContain("FromQuery", endpointSource);
+    }
+
+    [Fact]
+    public void GetWithExplicitRoute_IdPropertyNotInTemplate_BindsFromQuery()
+    {
+        // With an explicit route lacking the matching {placeholder}, an *Id property on a GET
+        // falls through to a proper [FromQuery] parameter rather than an attribute-less route
+        // parameter — so it is documented and bound correctly.
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record GetExternalUser(string ExternalId);
+
+            public class AuthHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Get, "external-user")]
+                public string Handle(GetExternalUser query) => "user";
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.Contains("MapGet", endpointSource);
+        Assert.Contains("external-user", endpointSource);
+        // The route stays literal — no synthesized {externalId} placeholder.
+        Assert.DoesNotContain("{externalId}", endpointSource);
+        // ExternalId binds from the query string, not the (placeholder-less) route.
+        Assert.Contains("[Microsoft.AspNetCore.Mvc.FromQuery]", endpointSource);
+        Assert.Contains("externalId", endpointSource);
+    }
+
+    [Fact]
+    public void FromBodyOnMessageParameter_SuppressesIdPromotion_BindsWholeMessageFromBody()
+    {
+        // Opt-out: [FromBody] on the handler's message parameter forces whole-message body
+        // binding even in convention mode. Without it, ApproveOrder(OrderId) would generate
+        // POST /orders/{orderId}/approve and lift OrderId out of the body; with it, OrderId
+        // stays in the body and no route/query placeholder is synthesized.
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record ApproveOrder(string OrderId);
+
+            public class OrderHandler
+            {
+                public Result Handle([Microsoft.AspNetCore.Mvc.FromBody] ApproveOrder command) => Result.Success();
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.NotNull(endpointSource);
+        Assert.Contains("MapPost", endpointSource);
+        // OrderId must NOT be promoted into the route or merged out of the body.
+        Assert.DoesNotContain("{orderId}", endpointSource);
+        Assert.DoesNotContain("message with", endpointSource);
+        Assert.DoesNotContain("FromQuery", endpointSource);
+        // The whole message binds from the request body.
+        Assert.Contains("[Microsoft.AspNetCore.Mvc.FromBody]", endpointSource);
+    }
+
+    [Fact]
     public void ActionVerbPrefix_GeneratesActionRouteWithId()
     {
         var source = """


### PR DESCRIPTION
## Problem

When `[HandlerEndpoint]` maps a POST/PUT/PATCH whose message is the request body, the generator's `*Id`-suffix heuristic lifted **every** property ending in `Id` into a separate route/query parameter — even when that property had no matching `{placeholder}` in the explicit route template. With an explicit route the template is used verbatim, so the promoted property became a phantom parameter:

- **Non-nullable `*Id`** → a required query value the body-only client never sends → **400 Bad Request** before the handler runs.
- **Nullable `*Id`** → absent query value **silently overwrites** the body-supplied value with `null` (via the generated `message with { … }` merge).

Repro: `[HandlerEndpoint(HandlerMethod.Post, "external-login")]` on a handler whose message has `string ExternalId` (no `{externalId}` token).

## Fix

Gate the `*Id`→route-param heuristic on `!hasExplicitRoute` in `HandlerAnalyzer.AnalyzeMessageParameters`. The heuristic exists to weave a `{placeholder}` into a **generated** route; with an explicit template there's nothing to weave. Legitimate route binding is unaffected because it's handled *before* the heuristic via the `{placeholder}` match and `[FromRoute]`.

A non-placeholder `*Id` now correctly falls through to:
- the **request body** for POST/PUT/PATCH, or
- a proper **`[FromQuery]`** parameter for GET/DELETE.

## Opt-out: `[FromBody]` on the message parameter

For body commands, applying `[FromBody]` to the handler's message parameter forces whole-message body binding and suppresses the `*Id` route/query conventions **even in convention mode**:

```csharp
public Result Handle([FromBody] ApproveOrder command) => Result.Success();
// OrderId stays in the body instead of being lifted into POST /orders/{orderId}/approve
```

Form binding (`IFormFile`), explicit `{placeholder}` segments, and `[FromRoute]`/`[FromQuery]`/`[FromHeader]` property attributes are still honored.

## Notes

- The build-time diagnostic suggested "at minimum" in the report is moot after the gate — with an explicit route the surprising extraction no longer happens, and in convention mode the `*Id` is genuinely woven into the generated route (not a phantom).
- The parallel copy of the heuristic in `MediatorInfoAnalyzer.GetRouteParameters` (FMED017 route-collision diagnostic) is left as-is: its route params are ignored once an explicit route is present, so it already computes the correct route string.

## Tests & docs

- 3 regression tests in `EndpointGenerationTests.cs` (explicit-route `*Id` → body; explicit-route `*Id` → `[FromQuery]`; `[FromBody]` suppressing convention promotion).
- Full suite: **650/650 pass**, including the byte-identical Verify snapshot (convention-mode output unchanged).
- `docs/guide/endpoints.md` updated: clarified "Route Parameters" and added "Binding the Whole Message From the Body".

🤖 Generated with [Claude Code](https://claude.com/claude-code)