### PR TITLE
[codex] Use Lume pretty URLs for docs

### DIFF
--- a/docs/_theme/mod.ts
+++ b/docs/_theme/mod.ts
@@ -30,7 +30,6 @@ import type {
     ThemeLabels,
 } from "./types.ts";
 import {
-    cleanPageUrl,
     docsUrlPrefix,
     extractHeadings,
     isDocsPath,
@@ -88,7 +87,6 @@ function applyDocsTheme(
             .filter((page) => isMarkdownPage(page))
             .map((page) => {
                 const data = page.data as DocsData;
-                useCleanUrlWithHtmlOutput(page);
                 const markdown = readOriginalSource(page);
                 const html = transformBadgeTags(
                     normalizeInternalLinks(page.text, data.url),
@@ -170,13 +168,13 @@ function applyDocsTheme(
         }
 
         for (const entry of contentPages) {
-            const redirectUrl = trailingSlashRedirectUrl(entry.data.url);
-            if (!redirectUrl) {
+            const legacyUrl = legacyHtmlUrl(entry.data.url);
+            if (!legacyUrl) {
                 continue;
             }
 
             allPages.push(Page.create({
-                url: redirectUrl,
+                url: legacyUrl,
                 content: renderRedirect(entry.data.url),
                 unlisted: true,
                 search: false,
@@ -237,6 +235,10 @@ async function highlightContentEntries(
     entries: ContentEntry[],
     theme: ResolvedDocsThemeOptions,
 ) {
+    for (const entry of entries) {
+        entry.page.content = entry.html;
+    }
+
     await highlightCodeBlocks(entries.map((entry) => entry.page), theme);
     for (const entry of entries) {
         applyCodeLineAnnotations(entry.page);
@@ -255,43 +257,6 @@ function readOriginalSource(page: Page): string {
         : page.text;
 }
 
-function useCleanUrlWithHtmlOutput(page: Page) {
-    const data = page.data as DocsData;
-    data.url = cleanPageUrl(data.url);
-    const outputPath = htmlOutputPath(data.url);
-
-    Object.defineProperty(page, "outputPath", {
-        configurable: true,
-        get: () => outputPath,
-    });
-    markPageAsHtml(page);
-}
-
-function htmlOutputPath(url: string) {
-    if (url === "/" || url === "") {
-        return "/index.html";
-    }
-
-    return `${url.replace(/\/$/, "")}.html`;
-}
-
-function trailingSlashRedirectUrl(url: string) {
-    const normalized = url.replace(/\/$/, "");
-    if (!normalized || normalized === "/" || normalized.includes(".")) {
-        return undefined;
-    }
-
-    return `${normalized}/index.html`;
-}
-
-function markPageAsHtml(page: Page) {
-    // Lume's sitemap plugin reads from site.search.pages(), which only returns
-    // pages classified as HTML. Extensionless canonical URLs need that preserved.
-    Object.defineProperty(page, "isHTML", {
-        configurable: true,
-        get: () => true,
-    });
-}
 function normalizeLayout(data: DocsData) {
     if (data.layout === undefined) {
         return;

--- a/docs/_theme/utils.ts
+++ b/docs/_theme/utils.ts
@@ -149,7 +149,7 @@ function prettyPagePath(path: string): string {
     }
 
     if (path === "/" || path.endsWith("/")) {
-        return path === "/" ? "/" : path.slice(0, -1);
+        return path;
     }
 
     if (path === "index.md" || path === "index.html") {
@@ -157,14 +157,24 @@ function prettyPagePath(path: string): string {
     }
 
     if (path.endsWith("/index.md") || path.endsWith("/index.html")) {
-        return path.replace(/\/?index\.(?:md|html)$/, "") || "/";
+        return withTrailingSlash(
+            path.replace(/\/?index\.(?:md|html)$/, "") || "/",
+        );
     }
 
     if (path.endsWith(".md") || path.endsWith(".html")) {
-        return path.replace(/\.(?:md|html)$/, "");
+        return withTrailingSlash(path.replace(/\.(?:md|html)$/, ""));
     }
 
-    return path;
+    if (path.split("/").pop()?.includes(".")) {
+        return path;
+    }
+
+    return withTrailingSlash(path);
+}
+
+function withTrailingSlash(path: string): string {
+    return path === "/" || path.endsWith("/") ? path : `${path}/`;
 }
 
 export function firstHeading(data: DocsData): string | undefined {


### PR DESCRIPTION
## Summary

- use Lume's standard `prettyUrls` output for docs pages so clean URLs generate `index.html` files in folders
- add generated legacy redirect pages from `/guide/foo.html` to `/guide/foo/`
- normalize internal docs links, sitemap/search URLs, and Shiki post-processing around trailing-slash pretty URLs

## Why

The previous clean-URL experiment generated extensionless files, which static hosting can serve with the wrong content type. This keeps the clean URL behavior while returning to static-host-compatible folder output.

## Validation

- `deno task fmt`
- `deno task check`
- `deno task build`
- verified `_site/guide/troubleshooting/index.html` is the full page
- verified `_site/guide/troubleshooting.html` is a redirect stub
- verified no extensionless guide files are emitted
