### PR TITLE
[codex] Update docs Pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,13 +38,13 @@ jobs:
       working-directory: docs
 
     - name: Setup Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@v6
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: docs/_site
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5


### PR DESCRIPTION
Updates the docs deploy workflow to actions/configure-pages@v6, actions/upload-pages-artifact@v5, and actions/deploy-pages@v5 to remove the GitHub Actions Node.js 20 deprecation warning. Verified with git diff --check.