### PR TITLE
Downgrade Microsoft.CodeAnalysis to 5.0.0 for full .NET 10 SDK compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ nul
 
 "samples/CleanArchitectureSample/src/Web/obj//Debug/
 
+
+# obj directory with mangled backslash path emitted by some build targets on Linux
+[Oo]bj\\*/

--- a/src/Foundatio.Mediator.CodeFixes/Foundatio.Mediator.CodeFixes.csproj
+++ b/src/Foundatio.Mediator.CodeFixes/Foundatio.Mediator.CodeFixes.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Foundatio.Mediator/Foundatio.Mediator.csproj
+++ b/src/Foundatio.Mediator/Foundatio.Mediator.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Foundatio.Mediator.Abstractions\Foundatio.Mediator.Abstractions.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -185,7 +185,7 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
                 public Result<OrderView> Handle(CreateOrder command)
                 {
                     var order = new OrderView("1", command.Name);
-                    return Result.Created(order);
+                    return Result<OrderView>.Created(order);
                 }
             }
             """;
@@ -945,7 +945,7 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
             public class ProductHandler
             {
                 public Result<string> Handle(CreateProduct command)
-                    => Result.Created(command.Name, "/products/1");
+                    => Result<string>.Created(command.Name, "/products/1");
             }
             """;
 

--- a/tests/Foundatio.Mediator.Tests/Foundatio.Mediator.Tests.csproj
+++ b/tests/Foundatio.Mediator.Tests/Foundatio.Mediator.Tests.csproj
@@ -36,10 +36,10 @@
     <PackageReference Include="Verify.DiffPlex" Version="3.2.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
     <!-- Roslyn packages (use matching overrides to reduce conflicts) -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0"
       PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0"
       PrivateAssets="all" />
     <!-- TestHost for E2E endpoint tests -->


### PR DESCRIPTION
## Problem

The source generator and code fixes referenced **Microsoft.CodeAnalysis 5.3.0**, which requires the compiler from SDK 10.0.3xx or newer. Anyone building with an earlier .NET 10 SDK (10.0.100 through 10.0.2xx, Roslyn 5.0) hit:

```
warning CS9057: Analyzer assembly ... references version '5.3.0.0' of the compiler,
which is newer than the currently running version '5.0.0.0'.
```

…and the generator **silently didn't run** — no handler wrappers, no `MapMediatorEndpoints`, cascading build errors with no obvious cause.

## Fix

Downgrade `Microsoft.CodeAnalysis.CSharp` / `.CSharp.Workspaces` / `.Common` to **5.0.0** — the version shipped with SDK 10.0.100 — so the package works on every .NET 10 SDK. No generator code changes were needed; nothing in the generator uses 5.3-only APIs. `Microsoft.CodeAnalysis.Analyzers` stays at 5.3.0: it's a private dev-time dependency (analyzer-authoring rules), has no 5.0.0 release, and has no effect on consumer compatibility.

## Test fixes the downgrade surfaced

Two endpoint tests had handler source calling **non-existent overloads** — `Result.Created(order)` and `Result.Created(name, location)` instead of `Result<T>.Created(...)`. That source never compiled (CS1503), but the test harness only asserts diagnostics for *generated* files, so the invalid input was never caught. It passed under Roslyn 5.3 only because 5.3's error-recovery binding reports the intended `Created` method for the broken invocation; 5.0 binds it to the implicit conversion operator, so status-code detection correctly found nothing. Fixed the test source to the documented API (`Result<OrderView>.Created(order)`), which behaves identically on both Roslyn versions.

## Verification

- Full solution build + all 668 tests pass on **SDK 10.0.109 (Roslyn 5.0)** — previously failed with CS9057
- Full solution build + all 668 tests pass on **SDK 10.0.301 (Roslyn 5.3)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)