### PR TITLE
Add generic Result factory overloads with inferred value type

### DIFF
--- a/docs/guide/result-types.md
+++ b/docs/guide/result-types.md
@@ -85,10 +85,11 @@ public enum ResultStatus
 ```csharp
 // Simple success
 return Result.Success();
-return Result<User>.Success(user);
+return Result.Success(user);   // T inferred — same as Result<User>.Success(user)
 
-// Created with location
-return Result<Order>.Created(order, $"/orders/{order.Id}");
+// Created with the new value (T inferred from the argument)
+return Result.Created(order);
+return Result.Created(order, $"/orders/{order.Id}");
 
 // Accepted for deferred processing
 return Result.Accepted("Order queued", $"/orders/{order.Id}/status");
@@ -99,6 +100,11 @@ return Result.NoContent();
 // Implicit conversion from value
 return user; // Automatically becomes Result<User>.Success(user)
 ```
+
+> **String values:** for `Result<string>`, calls like `Result.Created("...")` and
+> `Result.Ok("...")` bind to the non-generic overloads, where the string argument
+> means *location* and *message* respectively. Use `Result<string>.Created(value)`
+> / `Result<string>.Ok(value)` when the string is the result value.
 
 ### File Results
 

--- a/docs/guide/result-types.md
+++ b/docs/guide/result-types.md
@@ -101,10 +101,12 @@ return Result.NoContent();
 return user; // Automatically becomes Result<User>.Success(user)
 ```
 
-> **String values:** for `Result<string>`, calls like `Result.Created("...")` and
-> `Result.Ok("...")` bind to the non-generic overloads, where the string argument
-> means *location* and *message* respectively. Use `Result<string>.Created(value)`
-> / `Result<string>.Ok(value)` when the string is the result value.
+> **String values:** for `Result<string>`, calls like `Result.Created("...")`,
+> `Result.Ok("...")`, and `Result.Success("...")` bind to the non-generic
+> overloads, where the string argument means *location* (for `Created`) or
+> *message* (for `Ok`/`Success`). Use `Result<string>.Created(value)` /
+> `Result<string>.Ok(value)` / `Result<string>.Success(value)` when the string
+> is the result value.
 
 ### File Results
 

--- a/src/Foundatio.Mediator.Abstractions/Result.cs
+++ b/src/Foundatio.Mediator.Abstractions/Result.cs
@@ -95,6 +95,30 @@ public sealed class Result : IResult
     };
 
     /// <summary>
+    /// Creates a successful result with a value. Equivalent to <see cref="Result{T}.Ok(T)"/>
+    /// with the value type inferred from the argument.
+    /// <para>
+    /// Note: when the value is a <see cref="string"/>, overload resolution prefers
+    /// <see cref="Ok(string)"/> and the argument is treated as the success message —
+    /// use <c>Result&lt;string&gt;.Ok(value)</c> to be explicit.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the result value.</typeparam>
+    /// <param name="value">The result value.</param>
+    /// <returns>A successful result with a value.</returns>
+    public static Result<T> Ok<T>(T value) => Result<T>.Ok(value);
+
+    /// <summary>
+    /// Creates a successful result with a value and a message. Equivalent to
+    /// <see cref="Result{T}.Ok(T, string)"/> with the value type inferred from the argument.
+    /// </summary>
+    /// <typeparam name="T">The type of the result value.</typeparam>
+    /// <param name="value">The result value.</param>
+    /// <param name="message">The success message.</param>
+    /// <returns>A successful result with a value and a message.</returns>
+    public static Result<T> Ok<T>(T value, string message) => Result<T>.Ok(value, message);
+
+    /// <summary>
     /// Creates a successful result. Alias for <see cref="Ok()"/>.
     /// </summary>
     /// <returns>A successful result.</returns>
@@ -106,6 +130,28 @@ public sealed class Result : IResult
     /// <param name="successMessage">The success message.</param>
     /// <returns>A successful result with a message.</returns>
     public static Result Success(string successMessage) => Ok(successMessage);
+
+    /// <summary>
+    /// Creates a successful result with a value. Alias for <see cref="Ok{T}(T)"/>.
+    /// <para>
+    /// Note: when the value is a <see cref="string"/>, overload resolution prefers
+    /// <see cref="Success(string)"/> and the argument is treated as the success message —
+    /// use <c>Result&lt;string&gt;.Success(value)</c> to be explicit.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the result value.</typeparam>
+    /// <param name="value">The result value.</param>
+    /// <returns>A successful result with a value.</returns>
+    public static Result<T> Success<T>(T value) => Result<T>.Success(value);
+
+    /// <summary>
+    /// Creates a successful result with a value and a message. Alias for <see cref="Ok{T}(T, string)"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the result value.</typeparam>
+    /// <param name="value">The result value.</param>
+    /// <param name="successMessage">The success message.</param>
+    /// <returns>A successful result with a value and a message.</returns>
+    public static Result<T> Success<T>(T value, string successMessage) => Result<T>.Success(value, successMessage);
 
     /// <summary>
     /// Creates a result indicating successful creation of a resource.
@@ -159,6 +205,31 @@ public sealed class Result : IResult
         Status = ResultStatus.Created,
         Location = location
     };
+
+    /// <summary>
+    /// Creates a result indicating successful creation of a resource with the created value.
+    /// Equivalent to <see cref="Result{T}.Created(T)"/> with the value type inferred from the argument.
+    /// <para>
+    /// Note: when the value is a <see cref="string"/>, overload resolution prefers
+    /// <see cref="Created(string)"/> and the argument is treated as the location —
+    /// use <c>Result&lt;string&gt;.Created(value)</c> to be explicit.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of the created value.</typeparam>
+    /// <param name="value">The created value.</param>
+    /// <returns>A result with Created status and a value.</returns>
+    public static Result<T> Created<T>(T value) => Result<T>.Created(value);
+
+    /// <summary>
+    /// Creates a result indicating successful creation of a resource with the created value and
+    /// its location. Equivalent to <see cref="Result{T}.Created(T, string)"/> with the value type
+    /// inferred from the argument.
+    /// </summary>
+    /// <typeparam name="T">The type of the created value.</typeparam>
+    /// <param name="value">The created value.</param>
+    /// <param name="location">The location of the created resource.</param>
+    /// <returns>A result with Created status, a value, and a location.</returns>
+    public static Result<T> Created<T>(T value, string location) => Result<T>.Created(value, location);
 
     /// <summary>
     /// Creates a result indicating no content.

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -185,7 +185,8 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
                 public Result<OrderView> Handle(CreateOrder command)
                 {
                     var order = new OrderView("1", command.Name);
-                    return Result<OrderView>.Created(order);
+                    // Type argument inferred via Result.Created<T>(T value)
+                    return Result.Created(order);
                 }
             }
             """;
@@ -193,7 +194,15 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
         var refs = GetAspNetCoreReferences();
         if (refs.Length == 0) return;
 
-        var (_, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var (compilation, _, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+
+        // The inferred form must bind for real — guard against error-recovery false positives
+        // (the harness only asserts diagnostics for generated files, not the input source).
+        var inputErrors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error && d.Location.SourceTree?.FilePath.EndsWith(".g.cs") != true)
+            .ToList();
+        Assert.Empty(inputErrors);
+
         var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
 
         Assert.NotNull(endpointSource);

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -198,7 +198,7 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
 
         // The inferred form must bind for real — guard against error-recovery false positives
         // (the harness only asserts diagnostics for generated files, not the input source).
-        var inputErrors = compilation.GetDiagnostics()
+        var inputErrors = compilation.GetDiagnostics(TestContext.Current.CancellationToken)
             .Where(d => d.Severity == DiagnosticSeverity.Error && d.Location.SourceTree?.FilePath.EndsWith(".g.cs") != true)
             .ToList();
         Assert.Empty(inputErrors);

--- a/tests/Foundatio.Mediator.Tests/ResultTests.cs
+++ b/tests/Foundatio.Mediator.Tests/ResultTests.cs
@@ -726,7 +726,7 @@ public class ResultTests
         var widget = new Widget(1, "Gear");
 
         // No explicit Result<Widget> — T is inferred from the argument
-        Result<Widget> result = Result.Created(widget);
+        var result = Result.Created(widget);
 
         Assert.True(result.IsSuccess);
         Assert.Equal(ResultStatus.Created, result.Status);
@@ -739,7 +739,7 @@ public class ResultTests
     {
         var widget = new Widget(1, "Gear");
 
-        Result<Widget> result = Result.Created(widget, "/widgets/1");
+        var result = Result.Created(widget, "/widgets/1");
 
         Assert.Equal(ResultStatus.Created, result.Status);
         Assert.Same(widget, result.Value);
@@ -751,7 +751,7 @@ public class ResultTests
     {
         var widget = new Widget(2, "Sprocket");
 
-        Result<Widget> result = Result.Ok(widget);
+        var result = Result.Ok(widget);
 
         Assert.Equal(ResultStatus.Ok, result.Status);
         Assert.Same(widget, result.Value);
@@ -762,7 +762,7 @@ public class ResultTests
     {
         var widget = new Widget(2, "Sprocket");
 
-        Result<Widget> result = Result.Ok(widget, "found it");
+        var result = Result.Ok(widget, "found it");
 
         Assert.Equal(ResultStatus.Ok, result.Status);
         Assert.Same(widget, result.Value);
@@ -774,7 +774,7 @@ public class ResultTests
     {
         var widget = new Widget(3, "Cog");
 
-        Result<Widget> result = Result.Success(widget);
+        var result = Result.Success(widget);
 
         Assert.Equal(ResultStatus.Ok, result.Status);
         Assert.Same(widget, result.Value);
@@ -785,7 +785,7 @@ public class ResultTests
     {
         var widget = new Widget(3, "Cog");
 
-        Result<Widget> result = Result.Success(widget, "done");
+        var result = Result.Success(widget, "done");
 
         Assert.Equal(ResultStatus.Ok, result.Status);
         Assert.Same(widget, result.Value);

--- a/tests/Foundatio.Mediator.Tests/ResultTests.cs
+++ b/tests/Foundatio.Mediator.Tests/ResultTests.cs
@@ -813,4 +813,14 @@ public class ResultTests
         Assert.Equal(ResultStatus.Ok, result.Status);
         Assert.Equal("all good", result.Message);
     }
+
+    [Fact]
+    public void Success_WithStringArgument_StillBindsToMessageOverload()
+    {
+        // Same string caveat as Ok: Success(string successMessage) wins over Success<T>(T value).
+        Result result = Result.Success("saved");
+
+        Assert.Equal(ResultStatus.Ok, result.Status);
+        Assert.Equal("saved", result.Message);
+    }
 }

--- a/tests/Foundatio.Mediator.Tests/ResultTests.cs
+++ b/tests/Foundatio.Mediator.Tests/ResultTests.cs
@@ -717,4 +717,100 @@ public class ResultTests
         Assert.Equal("application/octet-stream", fileResult.ContentType);
         Assert.Null(fileResult.FileName);
     }
+
+    public record Widget(int Id, string Name);
+
+    [Fact]
+    public void Created_WithValue_InfersTypeAndSetsValue()
+    {
+        var widget = new Widget(1, "Gear");
+
+        // No explicit Result<Widget> — T is inferred from the argument
+        Result<Widget> result = Result.Created(widget);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(ResultStatus.Created, result.Status);
+        Assert.Same(widget, result.Value);
+        Assert.Empty(result.Location);
+    }
+
+    [Fact]
+    public void Created_WithValueAndLocation_SetsBoth()
+    {
+        var widget = new Widget(1, "Gear");
+
+        Result<Widget> result = Result.Created(widget, "/widgets/1");
+
+        Assert.Equal(ResultStatus.Created, result.Status);
+        Assert.Same(widget, result.Value);
+        Assert.Equal("/widgets/1", result.Location);
+    }
+
+    [Fact]
+    public void Ok_WithValue_InfersTypeAndSetsValue()
+    {
+        var widget = new Widget(2, "Sprocket");
+
+        Result<Widget> result = Result.Ok(widget);
+
+        Assert.Equal(ResultStatus.Ok, result.Status);
+        Assert.Same(widget, result.Value);
+    }
+
+    [Fact]
+    public void Ok_WithValueAndMessage_SetsBoth()
+    {
+        var widget = new Widget(2, "Sprocket");
+
+        Result<Widget> result = Result.Ok(widget, "found it");
+
+        Assert.Equal(ResultStatus.Ok, result.Status);
+        Assert.Same(widget, result.Value);
+        Assert.Equal("found it", result.Message);
+    }
+
+    [Fact]
+    public void Success_WithValue_IsAliasForOk()
+    {
+        var widget = new Widget(3, "Cog");
+
+        Result<Widget> result = Result.Success(widget);
+
+        Assert.Equal(ResultStatus.Ok, result.Status);
+        Assert.Same(widget, result.Value);
+    }
+
+    [Fact]
+    public void Success_WithValueAndMessage_SetsBoth()
+    {
+        var widget = new Widget(3, "Cog");
+
+        Result<Widget> result = Result.Success(widget, "done");
+
+        Assert.Equal(ResultStatus.Ok, result.Status);
+        Assert.Same(widget, result.Value);
+        Assert.Equal("done", result.Message);
+    }
+
+    [Fact]
+    public void Created_WithStringArgument_StillBindsToLocationOverload()
+    {
+        // Documents overload resolution for T = string: the non-generic Created(string location)
+        // is preferred over Created<T>(T value), so the argument is a location, not a value.
+        // Use Result<string>.Created(value) when a string *value* is intended.
+        Result result = Result.Created("/orders/1");
+
+        Assert.Equal(ResultStatus.Created, result.Status);
+        Assert.Equal("/orders/1", result.Location);
+    }
+
+    [Fact]
+    public void Ok_WithStringArgument_StillBindsToMessageOverload()
+    {
+        // Same string caveat as Created: Ok(string message) wins over Ok<T>(T value).
+        Result result = Result.Ok("all good");
+
+        Assert.Equal(ResultStatus.Ok, result.Status);
+        Assert.Equal("all good", result.Message);
+    }
 }


### PR DESCRIPTION
Follow-up from the discussion on #269: `return Result.Created(order);` *feels* like it should work with `T` inferred — but it didn't, because the value-carrying factories only existed on `Result<T>`, and C# never infers a class's type argument from a static member call. Writing it the intuitive way was a compile error, forcing the verbose `Result<OrderView>.Created(order)` form.

## What's added

Generic pass-through overloads on the non-generic `Result`, so the natural spelling works:

```csharp
return Result.Created(order);                          // Result<OrderView>, inferred
return Result.Created(order, $"/orders/{order.Id}");   // with location
return Result.Ok(user);                                // Result<User>, inferred
return Result.Success(user, "saved");                  // alias, with message
```

Six overloads total: `Ok<T>(T)`, `Ok<T>(T, string)`, `Success<T>(T)`, `Success<T>(T, string)`, `Created<T>(T)`, `Created<T>(T, string)` — all one-line forwards to the existing `Result<T>` factories.

## The `T = string` caveat (deliberate, documented, pinned by tests)

For string arguments, overload resolution prefers the existing non-generic overloads: `Result.Created("...")` still means *location* and `Result.Ok("...")` still means *message*. This preserves existing behavior exactly (non-generic methods win ties, so nothing changes for current code). The XML docs on the new overloads call it out, the docs guide gets a note, and two tests pin the resolution so it can't drift silently. Use `Result<string>.Created(value)` when a string *value* is intended.

## Endpoint status detection

The generator's status-code detection keys on method name + containing type, so the new overloads are picked up unchanged — `return Result.Created(order)` documents `201` on generated endpoints. Notably, this is the same source pattern that previously *appeared* to work only via Roslyn 5.3 error-recovery binding (see #269); it now binds for real. The endpoint test additionally asserts the input source compiles cleanly, guarding against that class of false positive going forward.

## Tests

- 8 new unit tests covering all six overloads plus the two string-resolution pins
- Endpoint generation test exercises the inferred form end-to-end (binds cleanly → `.Produces<OrderView>(201)`)
- Full suite: **676 passed, 0 failed**

Note: independent of #268 and #269; a trivial overlap with #269's test-source edits may need a rebase depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)