### PR TITLE
Re-pin Microsoft.CodeAnalysis to 5.0.0 for .NET 10 SDK compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
     interval: weekly
   cooldown:
     default-days: 7
+  ignore:
+    # Pinned to 5.0.0 (#269): newer Roslyn requires SDK 10.0.3xx+ and breaks the
+    # generator (CS9057) on older .NET 10 SDKs. Bump manually with SDK 10.0.1xx verification.
+    - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+    - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
+    - dependency-name: "Microsoft.CodeAnalysis.Common"

--- a/src/Foundatio.Mediator.CodeFixes/Foundatio.Mediator.CodeFixes.csproj
+++ b/src/Foundatio.Mediator.CodeFixes/Foundatio.Mediator.CodeFixes.csproj
@@ -13,9 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Analyzers is exempt from the 5.0.0 pin below: it only lints this project's own code at
+         build time (never shipped, never loaded by consumer compilers) and has no 5.0.0 release. -->
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
-    <!-- Pinned to 5.0.0 (#269): 5.3.0 requires SDK 10.0.3xx+; older .NET 10 SDKs get CS9057
-         and the code fixes silently don't load. Do not bump without verifying on SDK 10.0.1xx. -->
+    <!-- Pinned to 5.0.0 (#269): the code fixes bind against this at load time, and 5.3.0 requires
+         SDK 10.0.3xx+ — older .NET 10 SDKs get CS9057 and the code fixes silently don't load.
+         Do not bump without verifying on SDK 10.0.1xx. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Foundatio.Mediator.CodeFixes/Foundatio.Mediator.CodeFixes.csproj
+++ b/src/Foundatio.Mediator.CodeFixes/Foundatio.Mediator.CodeFixes.csproj
@@ -14,7 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="all" />
+    <!-- Pinned to 5.0.0 (#269): 5.3.0 requires SDK 10.0.3xx+; older .NET 10 SDKs get CS9057
+         and the code fixes silently don't load. Do not bump without verifying on SDK 10.0.1xx. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Foundatio.Mediator/Foundatio.Mediator.csproj
+++ b/src/Foundatio.Mediator/Foundatio.Mediator.csproj
@@ -17,7 +17,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Foundatio.Mediator.Abstractions\Foundatio.Mediator.Abstractions.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
+    <!-- Pinned to 5.0.0 (#269): 5.3.0 requires SDK 10.0.3xx+; older .NET 10 SDKs get CS9057
+         and the generator silently doesn't run. Do not bump without verifying on SDK 10.0.1xx. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Foundatio.Mediator/Foundatio.Mediator.csproj
+++ b/src/Foundatio.Mediator/Foundatio.Mediator.csproj
@@ -16,9 +16,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Foundatio.Mediator.Abstractions\Foundatio.Mediator.Abstractions.csproj" />
+    <!-- Analyzers is exempt from the 5.0.0 pin below: it only lints this project's own code at
+         build time (never shipped, never loaded by consumer compilers) and has no 5.0.0 release. -->
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
-    <!-- Pinned to 5.0.0 (#269): 5.3.0 requires SDK 10.0.3xx+; older .NET 10 SDKs get CS9057
-         and the generator silently doesn't run. Do not bump without verifying on SDK 10.0.1xx. -->
+    <!-- Pinned to 5.0.0 (#269): the generator binds against this at load time, and 5.3.0 requires
+         SDK 10.0.3xx+ — older .NET 10 SDKs get CS9057 and the generator silently doesn't run.
+         Do not bump without verifying on SDK 10.0.1xx. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/Foundatio.Mediator.Tests/Foundatio.Mediator.Tests.csproj
+++ b/tests/Foundatio.Mediator.Tests/Foundatio.Mediator.Tests.csproj
@@ -35,11 +35,13 @@
     <PackageReference Include="Verify.XunitV3" Version="31.20.0" />
     <PackageReference Include="Verify.DiffPlex" Version="3.3.0" />
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
-    <!-- Roslyn packages (use matching overrides to reduce conflicts) -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0"
+    <!-- Roslyn packages (use matching overrides to reduce conflicts).
+         Pinned to 5.0.0 to match the generator/code fixes (#269) so tests exercise the
+         minimum supported Roslyn. Do not bump without verifying on SDK 10.0.1xx. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0"
       PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0"
       PrivateAssets="all" />
     <!-- TestHost for E2E endpoint tests -->


### PR DESCRIPTION
## Summary

Blocking fix found while preparing the v1.3.3 release: dependabot bumps #274 and #275 reverted the #269 Roslyn downgrade that shipped as a headline fix in v1.3.2. A generator built against Microsoft.CodeAnalysis 5.3.0 fails to load with `CS9057` — and silently doesn't run — on .NET 10 SDKs older than 10.0.3xx, so releasing from current main would reintroduce exactly what v1.3.2 fixed.

- Re-pins `Microsoft.CodeAnalysis.CSharp` (generator), `CSharp.Workspaces` (code fixes), and the test project's Roslyn packages to **5.0.0**, matching the #269 configuration. `Microsoft.CodeAnalysis.Analyzers` stays at 5.3.0 (private dev-time dependency, no consumer impact — same as #269).
- Adds csproj comments explaining the pin so it's visible at the reference site.
- Adds dependabot `ignore` rules for the three CodeAnalysis packages so future bumps must be manual and verified against SDK 10.0.1xx.

## Testing

Full solution builds and all 708 tests pass with the re-pinned versions (includes the #279 changes already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)