### PR TITLE
Add HTTP QUERY endpoint support

### DIFF
--- a/docs/guide/endpoints.md
+++ b/docs/guide/endpoints.md
@@ -334,7 +334,7 @@ arguments for maximum flexibility:
 
 | Property                 | Purpose                                                                                                                                                                                            |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Method`                 | Override inferred HTTP method (`HandlerMethod.Get`, `.Post`, `.Put`, `.Delete`, `.Patch`)                                                                                                          |
+| `Method`                 | Override inferred HTTP method (`HandlerMethod.Get`, `.Post`, `.Put`, `.Delete`, `.Patch`, `.Query`)                                                                                                |
 | `Route`                  | Custom route template (relative to group prefix; leading `/` for absolute)                                                                                                                         |
 | `Name`                   | OpenAPI operation ID                                                                                                                                                                               |
 | `Summary`                | Override XML doc summary for OpenAPI                                                                                                                                                               |
@@ -819,6 +819,34 @@ public record UpdateProduct(string ProductId, string? Name, decimal? Price);
 // → MapPut("/{productId}", async (string productId, [FromBody] UpdateProduct message, ...) =>
 //   { var mergedMessage = message with { ProductId = productId }; ... })
 ```
+
+### QUERY Requests
+
+[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html) defines QUERY as a
+safe, idempotent HTTP method for queries whose representation is carried in the
+request body. Opt in explicitly with `HandlerMethod.Query`:
+
+```csharp
+public record SearchProducts(string Expression, int Limit);
+
+public class ProductHandler
+{
+    [HandlerEndpoint(HandlerMethod.Query, "search")]
+    public Result<IReadOnlyList<Product>> Handle(SearchProducts query) { ... }
+}
+// → QUERY /api/products/search
+//   Content-Type: application/json
+//   { "expression": "category = 'books'", "limit": 50 }
+```
+
+QUERY endpoints always bind the message from the request body. ASP.NET Core
+rejects a missing or unsupported `Content-Type`, as required by RFC 10008. Use
+`AcceptsContentTypes` to publish the supported request formats in endpoint and
+OpenAPI metadata.
+
+The `Query*` message-name convention continues to infer GET for backward
+compatibility. Use `HandlerMethod.Query` whenever the actual QUERY method is
+intended.
 
 #### Custom body binding (non-JSON bodies)
 

--- a/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
+++ b/src/Foundatio.Mediator.Abstractions/HandlerEndpointAttribute.cs
@@ -75,6 +75,7 @@ public sealed class HandlerEndpointAttribute : Attribute
     /// When <see cref="HandlerMethod.Default"/>, the HTTP method is inferred from the message type name:
     /// Get*/Find*/Search*/List*/Query* → GET, Create*/Add*/New* → POST,
     /// Update*/Edit*/Modify*/Set* → PUT, Delete*/Remove* → DELETE, Patch* → PATCH.
+    /// QUERY is never inferred; use <see cref="HandlerMethod.Query"/> explicitly.
     /// </summary>
     public HandlerMethod Method { get; set; }
 

--- a/src/Foundatio.Mediator.Abstractions/HandlerMethod.cs
+++ b/src/Foundatio.Mediator.Abstractions/HandlerMethod.cs
@@ -34,5 +34,12 @@ public enum HandlerMethod
     /// <summary>
     /// HTTP PATCH — used for commands that partially update a resource.
     /// </summary>
-    Patch = 5
+    Patch = 5,
+
+    /// <summary>
+    /// HTTP QUERY — used for safe, idempotent queries whose query representation is carried
+    /// in the request body, as defined by
+    /// <see href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</see>.
+    /// </summary>
+    Query = 6
 }

--- a/src/Foundatio.Mediator/EndpointGenerator.cs
+++ b/src/Foundatio.Mediator/EndpointGenerator.cs
@@ -631,7 +631,8 @@ internal static class EndpointGenerator
         var route = routeOverride ?? GenerateRelativeRoute(endpoint);
         var wrapperClassName = HandlerGenerator.GetHandlerClassName(handler);
 
-        // Determine the Map method
+        // Determine the Map method. ASP.NET Core does not expose a MapQuery convenience method,
+        // so QUERY uses the generic MapMethods API.
         string mapMethod = httpMethod switch
         {
             "GET" => "MapGet",
@@ -639,6 +640,7 @@ internal static class EndpointGenerator
             "PUT" => "MapPut",
             "DELETE" => "MapDelete",
             "PATCH" => "MapPatch",
+            "QUERY" => "MapMethods",
             _ => "MapPost"
         };
 
@@ -657,6 +659,9 @@ internal static class EndpointGenerator
             source.Append($"var {epVarName} = {groupVarName}.{mapMethod}(\"{route}\", ");
         else
             source.Append($"{groupVarName}.{mapMethod}(\"{route}\", ");
+
+        if (httpMethod == "QUERY")
+            source.Append("new[] { \"QUERY\" }, ");
 
         // Generate the lambda
         GenerateEndpointLambda(source, handler, endpoint, hasAsParametersAttribute, hasFromBodyAttribute, wrapperClassName, assemblySuffix);

--- a/src/Foundatio.Mediator/HandlerAnalyzer.cs
+++ b/src/Foundatio.Mediator/HandlerAnalyzer.cs
@@ -649,6 +649,7 @@ internal static class HandlerAnalyzer
             3 => "PUT",
             4 => "DELETE",
             5 => "PATCH",
+            6 => "QUERY",
             _ => isStreaming ? "GET" : InferHttpMethod(messageType.Name)
         };
 
@@ -767,7 +768,7 @@ internal static class HandlerAnalyzer
 
         // Determine binding strategy. Form-bound messages (multipart upload) bind from the form,
         // not from a JSON body, so the two are mutually exclusive.
-        bool bindFromBody = (httpMethod is "POST" or "PUT" or "PATCH") && !bindFromForm;
+        bool bindFromBody = (httpMethod is "POST" or "PUT" or "PATCH" or "QUERY") && !bindFromForm;
 
         // An explicit [FromBody] on the message parameter forces whole-message body binding
         // regardless of HTTP method, and below it suppresses the "all properties covered by the
@@ -778,7 +779,7 @@ internal static class HandlerAnalyzer
 
         // For auto-generated action verb routes, check if all properties are already
         // covered by route params (IDs). If so, skip body binding.
-        if (bindFromBody && !explicitFromBody && actionVerb != null && !hasExplicitRoute)
+        if (bindFromBody && httpMethod != "QUERY" && !explicitFromBody && actionVerb != null && !hasExplicitRoute)
         {
             var allProperties = messageType.GetMembers()
                 .OfType<IPropertySymbol>()
@@ -796,7 +797,7 @@ internal static class HandlerAnalyzer
         // skip body binding — all data comes from the route (e.g., POST /{todoId}/complete).
         // An explicit [FromBody] opts out of this: the message binds from the body even when the
         // route could cover every property.
-        if (bindFromBody && !explicitFromBody && hasExplicitRoute && !string.IsNullOrEmpty(route))
+        if (bindFromBody && httpMethod != "QUERY" && !explicitFromBody && hasExplicitRoute && !string.IsNullOrEmpty(route))
         {
             var allProperties = messageType.GetMembers()
                 .OfType<IPropertySymbol>()
@@ -1067,11 +1068,11 @@ internal static class HandlerAnalyzer
             .Where(p => p.DeclaredAccessibility == Accessibility.Public && p.GetMethod != null)
             .ToList();
 
-        // A body-bound (POST/PUT/PATCH) message that exposes an IFormFile/IFormFileCollection/IFormCollection
+        // A body-bound (POST/PUT/PATCH/QUERY) message that exposes an IFormFile/IFormFileCollection/IFormCollection
         // property binds from multipart/form-data rather than from a JSON body: files bind by name and other
         // fields use [FromForm]. Without this the whole message gets [FromBody] and multipart requests fail
         // (415, and IFormFile cannot be deserialized from JSON anyway).
-        bool bindFromForm = httpMethod is "POST" or "PUT" or "PATCH"
+        bool bindFromForm = httpMethod is "POST" or "PUT" or "PATCH" or "QUERY"
             && properties.Any(p => IsFormParameterType(p.Type));
 
         foreach (var prop in properties)

--- a/src/Foundatio.Mediator/MediatorInfoAnalyzer.cs
+++ b/src/Foundatio.Mediator/MediatorInfoAnalyzer.cs
@@ -369,6 +369,7 @@ public sealed class MediatorInfoAnalyzer : DiagnosticAnalyzer
             3 => "PUT",
             4 => "DELETE",
             5 => "PATCH",
+            6 => "QUERY",
             _ => isStreaming ? "GET" : RouteConventions.InferHttpMethod(messageType.Name)
         };
         var routeParams = GetRouteParameters(messageType, inferredHttpMethod, actionVerb != null);

--- a/src/Foundatio.Mediator/Models/EndpointInfo.cs
+++ b/src/Foundatio.Mediator/Models/EndpointInfo.cs
@@ -8,7 +8,7 @@ namespace Foundatio.Mediator.Models;
 internal readonly record struct EndpointInfo
 {
     /// <summary>
-    /// The HTTP method (GET, POST, PUT, DELETE, PATCH).
+    /// The HTTP method (GET, POST, PUT, DELETE, PATCH, QUERY).
     /// </summary>
     public string HttpMethod { get; init; }
 
@@ -93,7 +93,7 @@ internal readonly record struct EndpointInfo
     public EquatableArray<EndpointParameterInfo> BindingParameters { get; init; }
 
     /// <summary>
-    /// Whether the message should be bound from body (POST/PUT/PATCH).
+    /// Whether the message should be bound from body (POST/PUT/PATCH/QUERY).
     /// </summary>
     public bool BindFromBody { get; init; }
 
@@ -107,7 +107,7 @@ internal readonly record struct EndpointInfo
 
     /// <summary>
     /// Whether the message should be bound from a multipart/form-data request.
-    /// Set when a POST/PUT/PATCH message exposes an <c>IFormFile</c>/<c>IFormFileCollection</c>/<c>IFormCollection</c>
+    /// Set when a POST/PUT/PATCH/QUERY message exposes an <c>IFormFile</c>/<c>IFormFileCollection</c>/<c>IFormCollection</c>
     /// property. Mutually exclusive with <see cref="BindFromBody"/>; the endpoint also emits <c>.DisableAntiforgery()</c>.
     /// </summary>
     public bool BindFromForm { get; init; }

--- a/src/Foundatio.Mediator/Utility/RouteConventions.cs
+++ b/src/Foundatio.Mediator/Utility/RouteConventions.cs
@@ -515,7 +515,7 @@ internal static class RouteConventions
 
         // ── From [HandlerEndpoint] ─────────────────────────────────
 
-        /// <summary>HTTP method override (1=GET,2=POST,3=PUT,4=DELETE,5=PATCH, 0=auto).</summary>
+        /// <summary>HTTP method override (1=GET,2=POST,3=PUT,4=DELETE,5=PATCH,6=QUERY, 0=auto).</summary>
         public int HttpMethodEnum { get; init; }
 
         /// <summary>Explicit route from [HandlerEndpoint(Route = "...")].</summary>
@@ -555,6 +555,7 @@ internal static class RouteConventions
             3 => "PUT",
             4 => "DELETE",
             5 => "PATCH",
+            6 => "QUERY",
             _ => input.IsStreaming ? "GET" : InferHttpMethod(input.MessageTypeName)
         };
 

--- a/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
+++ b/tests/Foundatio.Mediator.Tests/EndpointGenerationTests.cs
@@ -7,6 +7,49 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
     private static readonly MediatorGenerator Gen = new();
 
     [Fact]
+    public void QueryMethod_UsesMapMethodsAndAlwaysBindsRequestContentFromBody()
+    {
+        var source = """
+            using Foundatio.Mediator;
+
+            [assembly: MediatorConfiguration(EndpointDiscovery = EndpointDiscovery.All)]
+
+            public record SearchCatalog(string Term, int Limit);
+            public record ExecuteCatalog(string CatalogId);
+            public record QueryCatalogById(string Id);
+
+            public class CatalogHandler
+            {
+                [HandlerEndpoint(HandlerMethod.Query, "search")]
+                public string[] Handle(SearchCatalog query) => [];
+
+                [HandlerEndpoint(HandlerMethod.Query)]
+                public string[] Handle(ExecuteCatalog query) => [];
+
+                [HandlerEndpoint(HandlerMethod.Query, "{id}")]
+                public string[] Handle(QueryCatalogById query) => [];
+            }
+            """;
+
+        var refs = GetAspNetCoreReferences();
+        if (refs.Length == 0) return;
+
+        var (_, diagnostics, trees) = RunGenerator(source, [Gen], additionalReferences: refs);
+        var endpointSource = trees.FirstOrDefault(t => t.HintName == "_MediatorEndpoints.g.cs").Source;
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+        Assert.NotNull(endpointSource);
+        Assert.Equal(3, endpointSource!.Split("new[] { \"QUERY\" }").Length - 1);
+        Assert.Equal(3, endpointSource.Split("[Microsoft.AspNetCore.Mvc.FromBody]").Length - 1);
+        Assert.Contains("SearchCatalog message", endpointSource);
+        Assert.Contains("ExecuteCatalog message", endpointSource);
+        Assert.Contains("QueryCatalogById message", endpointSource);
+        AssertEndpoint(endpointSource, "QUERY", "/api/catalogs/search");
+        AssertEndpoint(endpointSource, "QUERY", "/api/catalogs/{catalogId}/execute");
+        AssertEndpoint(endpointSource, "QUERY", "/api/catalogs/{id}");
+    }
+
+    [Fact]
     public void GlobalRoutePrefix_GeneratesNestedMapGroup()
     {
         var source = """
@@ -3769,4 +3812,3 @@ public class EndpointGenerationTests(ITestOutputHelper output) : GeneratorTestBa
         Assert.DoesNotContain(".DisableAntiforgery()", endpointSource);
     }
 }
-

--- a/tests/Foundatio.Mediator.Tests/Integration/E2E_EndpointCallContextTests.cs
+++ b/tests/Foundatio.Mediator.Tests/Integration/E2E_EndpointCallContextTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text;
 using Foundatio.Xunit;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -31,6 +32,14 @@ public class E2E_EndpointCallContextTests(ITestOutputHelper output) : TestWithLo
             => httpContext.Request.Path.Value ?? "(null)";
     }
 
+    public record QueryEndpointRequest(string Term);
+
+    public class QueryEndpointHandler
+    {
+        [HandlerEndpoint(HandlerMethod.Query, "/query-endpoint-test")]
+        public string Handle(QueryEndpointRequest query) => $"result:{query.Term}";
+    }
+
     // ── Tests ──────────────────────────────────────────────────────────────
 
     [Fact]
@@ -53,6 +62,74 @@ public class E2E_EndpointCallContextTests(ITestOutputHelper output) : TestWithLo
 
         var result = await response.Content.ReadFromJsonAsync<string>(TestCancellationToken);
         Assert.Equal("/api/request-paths", result);
+    }
+
+    [Fact]
+    public async Task Endpoint_Query_BindsRequestContentAndInvokesHandler()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMediator(b => b.AddAssembly<QueryEndpointHandler>());
+
+        await using var app = builder.Build();
+        app.MapMediatorEndpoints();
+        await app.StartAsync(TestCancellationToken);
+
+        var client = app.GetTestClient();
+        using var request = new HttpRequestMessage(new HttpMethod("QUERY"), "/query-endpoint-test")
+        {
+            Content = JsonContent.Create(new { Term = "widgets" })
+        };
+
+        var response = await client.SendAsync(request, TestCancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<string>(TestCancellationToken);
+        Assert.Equal("result:widgets", result);
+    }
+
+    [Fact]
+    public async Task Endpoint_QueryWithoutContentType_FailsRequest()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMediator(b => b.AddAssembly<QueryEndpointHandler>());
+
+        await using var app = builder.Build();
+        app.MapMediatorEndpoints();
+        await app.StartAsync(TestCancellationToken);
+
+        var client = app.GetTestClient();
+        using var request = new HttpRequestMessage(new HttpMethod("QUERY"), "/query-endpoint-test")
+        {
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes("{\"term\":\"widgets\"}"))
+        };
+
+        var response = await client.SendAsync(request, TestCancellationToken);
+
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_QueryWithInvalidJson_FailsRequest()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMediator(b => b.AddAssembly<QueryEndpointHandler>());
+
+        await using var app = builder.Build();
+        app.MapMediatorEndpoints();
+        await app.StartAsync(TestCancellationToken);
+
+        var client = app.GetTestClient();
+        using var request = new HttpRequestMessage(new HttpMethod("QUERY"), "/query-endpoint-test")
+        {
+            Content = new StringContent("not-json", Encoding.UTF8, "application/json")
+        };
+
+        var response = await client.SendAsync(request, TestCancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     // ── POST with [FromHeader] on message property ─────────────────────────


### PR DESCRIPTION
## Summary

- add `HandlerMethod.Query` as an explicit endpoint method
- generate QUERY routes through ASP.NET Core `MapMethods`
- always bind QUERY messages from request content so `Content-Type` drives deserialization
- preserve the existing `Query*` message-name convention as GET for backward compatibility
- document the RFC 10008 behavior and explicit opt-in

## Why

RFC 10008 standardizes QUERY as a safe, idempotent HTTP method for server-side queries whose representation is carried in the request content. Foundatio.Mediator could not previously declare or generate QUERY endpoints.

## Behavior

QUERY endpoints require explicit `[HandlerEndpoint(HandlerMethod.Query, ...)]` configuration. Request bodies are not elided even when route values cover every message property. ASP.NET Core rejects missing or unsupported media types and inconsistent JSON content through the normal body-binding pipeline.

## Validation

- `dotnet build Foundatio.Mediator.slnx`
- `dotnet test --solution Foundatio.Mediator.slnx --no-build` — 712 passed

The build retains the existing `Microsoft.OpenApi` vulnerability warning in the Clean Architecture sample.