### PR TITLE
Intercept PublishAsync only when the static type can be the runtime type

### DIFF
--- a/src/Foundatio.Mediator/CallSiteAnalyzer.cs
+++ b/src/Foundatio.Mediator/CallSiteAnalyzer.cs
@@ -55,6 +55,13 @@ internal static class CallSiteAnalyzer
 
         ITypeSymbol messageType = argumentType.Type;
 
+        // PublishAsync dispatches on the runtime type. A call site typed as object, an interface, an abstract
+        // class or a type parameter cannot be resolved at compile time; leave it to the runtime path.
+        if (isPublish && (messageType.SpecialType == SpecialType.System_Object
+                          || messageType.TypeKind is TypeKind.Interface or TypeKind.TypeParameter or TypeKind.Dynamic
+                          || messageType.IsAbstract))
+            return null;
+
         ITypeSymbol? responseType = null;
         if (methodSymbol is { IsGenericMethod: true, TypeArguments.Length: 1 })
         {

--- a/src/Foundatio.Mediator/CallSiteAnalyzer.cs
+++ b/src/Foundatio.Mediator/CallSiteAnalyzer.cs
@@ -57,9 +57,11 @@ internal static class CallSiteAnalyzer
 
         // PublishAsync dispatches on the runtime type. A call site typed as object, an interface, an abstract
         // class or a type parameter cannot be resolved at compile time; leave it to the runtime path.
+        // Nullable value types box as their underlying type (or null), never as Nullable<T>.
         if (isPublish && (messageType.SpecialType == SpecialType.System_Object
                           || messageType.TypeKind is TypeKind.Interface or TypeKind.TypeParameter or TypeKind.Dynamic
-                          || messageType.IsAbstract))
+                          || messageType.IsAbstract
+                          || messageType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T))
             return null;
 
         ITypeSymbol? responseType = null;

--- a/src/Foundatio.Mediator/Models/TypeSymbolInfo.cs
+++ b/src/Foundatio.Mediator/Models/TypeSymbolInfo.cs
@@ -9,6 +9,16 @@ internal readonly record struct TypeSymbolInfo
     /// </summary>
     public string Identifier { get; init; }
     /// <summary>
+    /// Indicates the static type is always the runtime type: a sealed class, a value type, or an enum.
+    /// A publish call site whose message type is not final has to dispatch by the runtime type.
+    /// </summary>
+    public bool IsFinal { get; init; }
+    /// <summary>
+    /// The globally qualified name usable in <c>typeof(...)</c>, with special types spelled out
+    /// (<c>global::System.String</c>, never the <c>string</c> keyword).
+    /// </summary>
+    public string GlobalName { get; init; }
+    /// <summary>
     /// The full name of the type, including namespace and any generic parameters.
     /// This may use short names when types are in scope via using directives.
     /// </summary>
@@ -196,6 +206,8 @@ internal readonly record struct TypeSymbolInfo
         return new TypeSymbolInfo
         {
             Identifier = identifier,
+            IsFinal = typeSymbol.IsSealed || typeSymbol.IsValueType,
+            GlobalName = GetGlobalName(typeSymbol),
             FullName = typeSymbol.ToDisplayString(),
             QualifiedName = qualifiedName,
             UnwrappedFullName = unwrappedTypeFullName,
@@ -220,6 +232,15 @@ internal readonly record struct TypeSymbolInfo
             IsAsyncEnumerable = isAsyncEnumerable,
             AsyncEnumerableItemFullName = asyncEnumerableItemFullName
         };
+    }
+
+    private static readonly SymbolDisplayFormat s_globalNameFormat = SymbolDisplayFormat.FullyQualifiedFormat
+        .WithMiscellaneousOptions(SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions & ~SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+    private static string GetGlobalName(ITypeSymbol typeSymbol)
+    {
+        var name = typeSymbol.WithNullableAnnotation(NullableAnnotation.None).ToDisplayString(s_globalNameFormat);
+        return name.EndsWith("?") && typeSymbol.IsReferenceType ? name.Substring(0, name.Length - 1) : name;
     }
 
     /// <summary>

--- a/src/Foundatio.Mediator/PublishInterceptorGenerator.cs
+++ b/src/Foundatio.Mediator/PublishInterceptorGenerator.cs
@@ -98,9 +98,15 @@ internal static class PublishInterceptorGenerator
         source.AppendLine("{");
         source.IncrementIndent();
 
+        if (!messageType.IsFinal)
+        {
+            // A derived message must reach the handlers of its runtime type, which only the mediator knows.
+            source.AppendLine($"if (message.GetType() != typeof({messageType.GlobalName})) return mediator.PublishAsync(message, cancellationToken);");
+        }
+
         source.AppendLine($"var registry = ((global::Foundatio.Mediator.Mediator)mediator).Registry;");
         source.AppendLine($"if (registry.HasSubscribers) registry.TryWriteSubscription(message);");
-        source.AppendLine($"var handlers = registry.GetPublishHandlersForType(typeof(global::{messageType.FullName}));");
+        source.AppendLine($"var handlers = registry.GetPublishHandlersForType(typeof({messageType.GlobalName}));");
         source.AppendLine();
 
         switch (configuration.NotificationPublishStrategy)

--- a/tests/Foundatio.Mediator.Tests/Integration/E2E_PublishAsyncTests.cs
+++ b/tests/Foundatio.Mediator.Tests/Integration/E2E_PublishAsyncTests.cs
@@ -11,6 +11,96 @@ public class E2E_PublishAsyncTests(ITestOutputHelper output) : TestWithLoggingBa
     public interface IE2eEvent { }
     public record E2eEvent(string Name) : IE2eEvent;
     public record E2eCommand(string Name) : ICommand;
+    public readonly record struct ValueEvent(string Name);
+    public sealed record DerivedEvent(string Name) : E2eEvent(Name);
+
+    public class ValueEventHandler(EventCollector collector)
+    {
+        public void Handle(ValueEvent message) => collector.AddEvent(message.Name);
+    }
+
+    public class DerivedEventHandler(EventCollector collector)
+    {
+        public void Handle(DerivedEvent message) => collector.AddEvent("derived:" + message.Name);
+    }
+
+    public class ArrayEventHandler(EventCollector collector)
+    {
+        public void Handle(string[] message) => collector.AddEvent(message[0]);
+    }
+
+    [Fact]
+    public async Task PublishAsync_CovariantArray_DispatchesToRuntimeTypeHandler()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<EventCollector>();
+        services.AddMediator(b => b.AddAssembly<ValueEvent>());
+        await using var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+        object[] message = new string[] { "array" };
+
+        await mediator.PublishAsync(message, TestCancellationToken);
+
+        Assert.Equal(["array"], provider.GetRequiredService<EventCollector>().Events);
+    }
+
+    [Fact]
+    public async Task PublishAsync_NullableValueType_DispatchesToUnderlyingTypeHandler()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<EventCollector>();
+        services.AddMediator(b => b.AddAssembly<ValueEvent>());
+        await using var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+        ValueEvent? message = new ValueEvent("nullable");
+
+        await mediator.PublishAsync(message, TestCancellationToken);
+
+        Assert.Equal(["nullable"], provider.GetRequiredService<EventCollector>().Events);
+    }
+
+    [Theory]
+    [InlineData("object")]
+    [InlineData("interface")]
+    [InlineData("base")]
+    [InlineData("generic")]
+    public async Task PublishAsync_PolymorphicMessage_DispatchesToRuntimeTypeHandlers(string staticType)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<EventCollector>();
+        services.AddMediator(b => b.AddAssembly<DerivedEvent>());
+        await using var provider = services.BuildServiceProvider();
+        var mediator = provider.GetRequiredService<IMediator>();
+        var message = new DerivedEvent("event");
+
+        switch (staticType)
+        {
+            case "object":
+                await mediator.PublishAsync((object)message, TestCancellationToken);
+                break;
+            case "interface":
+                await mediator.PublishAsync((IE2eEvent)message, TestCancellationToken);
+                break;
+            case "base":
+                await mediator.PublishAsync((E2eEvent)message, TestCancellationToken);
+                break;
+            case "generic":
+                await PublishGenericAsync(mediator, message, TestCancellationToken);
+                break;
+        }
+
+        var events = provider.GetRequiredService<EventCollector>().Events;
+        Assert.Equal(3, events.Count);
+        Assert.Contains("derived:event", events);
+        Assert.Contains("second:event", events);
+        Assert.Contains("first:DerivedEvent", events);
+    }
+
+    private static ValueTask PublishGenericAsync<T>(IMediator mediator, T message, CancellationToken cancellationToken)
+        where T : class => mediator.PublishAsync(message, cancellationToken);
 
     public class EventCollector
     {

--- a/tests/Foundatio.Mediator.Tests/PublishInterceptorTests.cs
+++ b/tests/Foundatio.Mediator.Tests/PublishInterceptorTests.cs
@@ -1,0 +1,97 @@
+namespace Foundatio.Mediator.Tests;
+
+/// <summary>
+/// PublishAsync interceptors resolve handlers for the call site's static type, but the runtime
+/// publishes by the message's runtime type. These tests pin down when interception is allowed.
+/// </summary>
+public class PublishInterceptorTests(ITestOutputHelper output) : GeneratorTestBase(output)
+{
+    private const string Handlers = """
+        using System.Threading.Tasks;
+        using Foundatio.Mediator;
+
+        public interface IOrderEvent { string OrderId { get; } }
+        public record OrderCreated(string OrderId) : IOrderEvent;
+        public sealed record OrderShipped(string OrderId) : IOrderEvent;
+        public abstract record AuditEvent(string Source);
+        public record UserAudited(string Source, string User) : AuditEvent(Source);
+
+        public class OrderEventHandler
+        {
+            public Task HandleAsync(IOrderEvent evt) => Task.CompletedTask;
+        }
+
+        public class OrderCreatedHandler
+        {
+            public void Handle(OrderCreated evt) { }
+        }
+
+        public class UserAuditedHandler
+        {
+            public void Handle(UserAudited evt) { }
+        }
+        """;
+
+    [Fact]
+    public void ObjectInterfaceAndAbstractPublishSites_AreNotIntercepted()
+    {
+        var source = Handlers + """
+
+            public class Publisher(IMediator mediator)
+            {
+                public Task ByObject(object notification) => mediator.PublishAsync(notification).AsTask();
+                public Task ByInterface(IOrderEvent evt) => mediator.PublishAsync(evt).AsTask();
+                public Task ByAbstract(AuditEvent evt) => mediator.PublishAsync(evt).AsTask();
+                public Task Generic<T>(T evt) where T : class => mediator.PublishAsync(evt).AsTask();
+                public Task ByText() => mediator.PublishAsync("plain text").AsTask();
+            }
+            """;
+
+        var (_, _, trees) = RunGenerator(source, [new MediatorGenerator()]);
+
+        var interceptors = trees.FirstOrDefault(t => t.HintName == "_PublishInterceptors.g.cs").Source;
+        Assert.NotNull(interceptors);
+
+        // Only the string publish has a compile-time type the runtime will agree with
+        Assert.Contains("typeof(global::System.String)", interceptors);
+        Assert.DoesNotContain("IOrderEvent", interceptors);
+        Assert.DoesNotContain("AuditEvent", interceptors);
+        Assert.DoesNotContain("global::object", interceptors);
+        Assert.Equal(1, CountOccurrences(interceptors, "[InterceptsLocation("));
+    }
+
+    [Fact]
+    public void NonSealedMessage_FallsBackToRuntimeDispatchWhenDerived()
+    {
+        var source = Handlers + """
+
+            public class Publisher(IMediator mediator)
+            {
+                public Task Created(OrderCreated evt) => mediator.PublishAsync(evt).AsTask();
+                public Task Shipped(OrderShipped evt) => mediator.PublishAsync(evt).AsTask();
+            }
+            """;
+
+        var (_, _, trees) = RunGenerator(source, [new MediatorGenerator()]);
+        var interceptors = trees.First(t => t.HintName == "_PublishInterceptors.g.cs").Source;
+
+        // OrderCreated is an unsealed record: a derived record could be published through this site
+        Assert.Contains("if (message.GetType() != typeof(global::OrderCreated)) return mediator.PublishAsync(message, cancellationToken);", interceptors);
+
+        // OrderShipped is sealed: no guard needed
+        Assert.DoesNotContain("typeof(global::OrderShipped)) return mediator.PublishAsync", interceptors);
+        Assert.Contains("registry.GetPublishHandlersForType(typeof(global::OrderShipped))", interceptors);
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0, index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+}

--- a/tests/Foundatio.Mediator.Tests/PublishInterceptorTests.cs
+++ b/tests/Foundatio.Mediator.Tests/PublishInterceptorTests.cs
@@ -83,6 +83,32 @@ public class PublishInterceptorTests(ITestOutputHelper output) : GeneratorTestBa
         Assert.Contains("registry.GetPublishHandlersForType(typeof(global::OrderShipped))", interceptors);
     }
 
+    [Fact]
+    public void NullableValueTypePublishSites_AreNotIntercepted()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            using Foundatio.Mediator;
+
+            public readonly record struct ValueEvent(int Value);
+
+            public class Publisher(IMediator mediator)
+            {
+                public ValueTask Nullable(ValueEvent? evt) => mediator.PublishAsync(evt!);
+                public ValueTask NullableInt(int? evt) => mediator.PublishAsync(evt!);
+                public ValueTask Generic<T>(T? evt) where T : struct => mediator.PublishAsync(evt!);
+                public ValueTask Value(ValueEvent evt) => mediator.PublishAsync(evt);
+            }
+            """;
+
+        var (_, _, trees) = RunGenerator(source, [new MediatorGenerator()]);
+        var interceptors = trees.First(t => t.HintName == "_PublishInterceptors.g.cs").Source;
+
+        Assert.Equal(1, CountOccurrences(interceptors, "[InterceptsLocation("));
+        Assert.Contains("registry.GetPublishHandlersForType(typeof(global::ValueEvent))", interceptors);
+        Assert.DoesNotContain("message.GetType()", interceptors);
+    }
+
     private static int CountOccurrences(string text, string value)
     {
         int count = 0, index = 0;


### PR DESCRIPTION
`PublishAsync` dispatches by runtime type, but its generated interceptor used the call site's static type. This could skip concrete handlers for polymorphic messages or emit invalid `typeof(global::object)` / `typeof(global::string)` expressions.

The analyzer leaves object, interface, abstract, generic-parameter, dynamic, and nullable-value call sites to runtime dispatch. Nullable values box as the underlying type, so looking up `Nullable<T>` handlers is incorrect. Non-final types get a runtime-type guard; exact types retain the fast path. Generated type names use fully qualified CLR names.

Generator tests check compilation and interceptor selection. Integration tests verify nullable, object, interface, base-class, generic, and covariant-array dispatch. Rebased onto current `main` after #329 merged.

Validation: clean solution build with zero warnings/errors and full test suite passing on .NET SDK 10.0.111.
